### PR TITLE
Limit blueprint workflow to docs changes

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -3,8 +3,28 @@ name: Compile blueprint
 on:
   push:
     branches: ["main"]
+    paths:
+      - ".github/workflows/blueprint.yml"
+      - "blueprint/**"
+      - "home_page/**"
+      - "scripts/docs/**"
+      - "scripts/checks/dependency_audit.py"
+      - "lakefile.lean"
+      - "lake-manifest.json"
+      - "lean-toolchain"
+      - "README.md"
   pull_request:
     branches: ["main"]
+    paths:
+      - ".github/workflows/blueprint.yml"
+      - "blueprint/**"
+      - "home_page/**"
+      - "scripts/docs/**"
+      - "scripts/checks/dependency_audit.py"
+      - "lakefile.lean"
+      - "lake-manifest.json"
+      - "lean-toolchain"
+      - "README.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Avoid running the expensive blueprint/docs/site build for PRs that only touch unrelated code. The workflow still runs for docs/site inputs, dependency pins, README, and workflow changes.