### PR TITLE
Add CPU elementwise division node (Tape.div / TapeM.div)

### DIFF
--- a/NN/Runtime/Autograd/Engine/Core/Elementwise.lean
+++ b/NN/Runtime/Autograd/Engine/Core/Elementwise.lean
@@ -80,6 +80,29 @@ def mul {α : Type} [Mul α] [DecidableEq Shape] {s : Shape}
     }
   pure (t.addNode node)
 
+/-- Elementwise division. PyTorch: `torch.div` / `/`. Backward is the quotient rule
+`∂(a/b)/∂a = 1/b`, `∂(a/b)/∂b = −a/b²` (mirrors the CUDA `div` node; negation reuses
+`subSpec (fill 0)` as `sub` does, so no `Neg α` is required). Requires `[Context α]` like
+the sibling `abs`/`sqrt`/`exp` nodes (its `divSpec` forward rides the carrier's `/`). -/
+def div {α : Type} [Context α] [DecidableEq Shape] {s : Shape}
+  (t : Tape α) (aId bId : Nat) : Result (Tape α × Nat) := do
+  let a ← requireValue (α:=α) (t:=t) (s:=s) aId
+  let b ← requireValue (α:=α) (t:=t) (s:=s) bId
+  let y := divSpec a b
+  let node : Node α :=
+    { name := some "div"
+      value := AnyTensor.mk y
+      requires_grad := true
+      parents := [aId, bId]
+      backward := fun dLdyAny => do
+        let dLdy ← requireGrad (α := α) (τ := s) dLdyAny
+        let da : Tensor α s := divSpec dLdy b
+        let dLdyA : Tensor α s := mulSpec dLdy (divSpec a (mulSpec b b))
+        let db : Tensor α s := subSpec (fill (0 : α) s) dLdyA
+        pure [(aId, AnyTensor.mk da), (bId, AnyTensor.mk db)]
+    }
+  pure (t.addNode node)
+
 /-- Multiply a tensor by a scalar constant. PyTorch: `x * c` for Python scalar `c`. -/
 def scale {α : Type} [Mul α] [DecidableEq Shape] {s : Shape}
   (t : Tape α) (xId : Nat) (c : α) : Result (Tape α × Nat) := do

--- a/NN/Runtime/Autograd/Engine/Core/Elementwise.lean
+++ b/NN/Runtime/Autograd/Engine/Core/Elementwise.lean
@@ -80,10 +80,16 @@ def mul {α : Type} [Mul α] [DecidableEq Shape] {s : Shape}
     }
   pure (t.addNode node)
 
-/-- Elementwise division. PyTorch: `torch.div` / `/`. Backward is the quotient rule
-`∂(a/b)/∂a = 1/b`, `∂(a/b)/∂b = −a/b²` (mirrors the CUDA `div` node; negation reuses
-`subSpec (fill 0)` as `sub` does, so no `Neg α` is required). Requires `[Context α]` like
-the sibling `abs`/`sqrt`/`exp` nodes (its `divSpec` forward rides the carrier's `/`). -/
+/-- Elementwise division. PyTorch: `torch.div` / `/`. Backward is the ordinary quotient
+rule, valid for nonzero denominators: `∂(a/b)/∂a = 1/b`, `∂(a/b)/∂b = −a/b²` (mirrors the
+CUDA `div` node; negation reuses `subSpec (fill 0)` as `sub` does, so no `Neg α` is required).
+
+Domain: real calculus does not define the derivative of `a/b` at `b = 0`, so this backward is
+the genuine quotient rule only where `b ≠ 0`. The carrier's `/` (and hence `divSpec`) may
+totalize or be backend-dependent at `b = 0`, but no real-valued gradient is implied there.
+
+Requires `[Context α]` like the sibling `abs`/`sqrt`/`exp` nodes (its `divSpec` forward rides
+the carrier's `/`). -/
 def div {α : Type} [Context α] [DecidableEq Shape] {s : Shape}
   (t : Tape α) (aId bId : Nat) : Result (Tape α × Nat) := do
   let a ← requireValue (α:=α) (t:=t) (s:=s) aId

--- a/NN/Runtime/Autograd/Engine/TapeM.lean
+++ b/NN/Runtime/Autograd/Engine/TapeM.lean
@@ -115,6 +115,14 @@ def mul {α : Type} [Mul α] [DecidableEq Shape] {s : Shape}
   set t'
   pure id
 
+/-- StateT wrapper around `Tape.div`. PyTorch comparison: `torch.div(a, b)` / `a / b`. -/
+def div {α : Type} [Context α] [DecidableEq Shape] {s : Shape}
+  (aId bId : Nat) : TapeM α Nat := do
+  let t ← get
+  let (t', id) ← liftM (Tape.div (t := t) (s := s) aId bId)
+  set t'
+  pure id
+
 /-- StateT wrapper around `Tape.scale`. PyTorch comparison: `c * x` / `torch.mul(x, c)`. -/
 def scale {α : Type} [Mul α] [DecidableEq Shape] {s : Shape}
   (xId : Nat) (c : α) : TapeM α Nat := do

--- a/NN/Tests/Runtime/Rationals/ElementwiseDivTest.lean
+++ b/NN/Tests/Runtime/Rationals/ElementwiseDivTest.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 TorchLean
+Released under MIT license as described in the file LICENSE.
+Authors: TorchLean Team
+-/
+
+module
+
+public import NN.Runtime.Autograd.Utils
+public import NN.Entrypoint.Tensor
+
+/-!
+# ElementwiseDivTest
+
+Regression test for the CPU elementwise division node (`Tape.div` / `TapeM.div`) over `ℚ`.
+
+Exact rational arithmetic (no floating-point roundoff) lets us assert both the forward value
+`a / b` *and* the quotient-rule backward by exact equality:
+
+  `∂(a/b)/∂a = 1/b`,  `∂(a/b)/∂b = −a/b²`.
+
+With `a = [6, 8]`, `b = [2, 4]`, and upstream gradient `dLdy = [1, 1]`:
+
+  `y  = [3, 2]`,  `∂L/∂a = [1/2, 1/4]`,  `∂L/∂b = [−3/2, −1/2]`.
+-/
+
+open scoped NN.Spec.RationalAlgebraic
+
+@[expose] public section
+
+open Spec
+open Tensor
+
+namespace Tests
+namespace Rationals
+namespace ElementwiseDiv
+
+open Runtime.Autograd
+
+/-- Tag used for readable error messages. -/
+abbrev tag : String := "elementwise_div_test (Rat)"
+
+/-- Two-element vector shape. -/
+abbrev s2 : Shape := .dim 2 .scalar
+
+/-- Numerator `a`. -/
+def a : Tensor ℚ s2 := tensorND! [2] [6.0, 8.0]
+/-- Denominator `b`. -/
+def b : Tensor ℚ s2 := tensorND! [2] [2.0, 4.0]
+/-- Upstream gradient `∂L/∂y`. -/
+def dLdy : Tensor ℚ s2 := tensorND! [2] [1.0, 1.0]
+
+/-- Expected forward `a / b = [3, 2]`. -/
+def yExp : Tensor ℚ s2 := tensorND! [2] [3.0, 2.0]
+/-- Expected `∂L/∂a = dLdy / b = [1/2, 1/4]`. -/
+def daExp : Tensor ℚ s2 := tensorND! [2] [0.5, 0.25]
+/-- Expected `∂L/∂b = −dLdy·a/b² = [−3/2, −1/2]` (built by negating `[3/2, 1/2]`). -/
+def dbExp : Tensor ℚ s2 := - tensorND! [2] [1.5, 0.5]
+
+/-- Build a tape `y = a / b`, run the backward pass, and check the forward value and both
+input gradients against the exact rational references. -/
+def checkDiv : Runtime.Autograd.Result Bool := do
+  let t0 : Tape ℚ := Tape.empty
+  let m : TapeM ℚ _ := do
+    let aId ← TapeM.leaf a (name := some "a") (requires_grad := true)
+    let bId ← TapeM.leaf b (name := some "b") (requires_grad := true)
+    let yId ← TapeM.div (s := s2) aId bId
+    let t ← TapeM.getTape
+    let yVal ← liftM (Tape.requireValue (α := ℚ) (t := t) (s := s2) yId)
+    let grads ← liftM (Tape.backward (t := t) yId (Runtime.Autograd.AnyTensor.mk dLdy))
+    pure (aId, bId, yVal, grads)
+  let ((aId, bId, yVal, grads), _) ← TapeM.run t0 m
+  let da ← Train.requireGradTensor (tag := tag) (s := s2) grads aId
+  let db ← Train.requireGradTensor (tag := tag) (s := s2) grads bId
+  let okY  := decide (pretty yVal = pretty yExp)
+  let okDa := decide (pretty da = pretty daExp)
+  let okDb := decide (pretty db = pretty dbExp)
+  pure (okY && okDa && okDb)
+
+/-- Entrypoint (called by `NN/Tests/Runtime/Rationals/Suite.lean`). -/
+def run : IO Unit := do
+  match checkDiv with
+  | .ok true => IO.println "elementwise_div_test (Rat): OK"
+  | .ok false => throw <| IO.userError "elementwise_div_test (Rat): FAILED"
+  | .error msg => throw <| IO.userError s!"elementwise_div_test (Rat): {msg}"
+
+end ElementwiseDiv
+end Rationals
+end Tests

--- a/NN/Tests/Runtime/Rationals/Suite.lean
+++ b/NN/Tests/Runtime/Rationals/Suite.lean
@@ -8,6 +8,7 @@ module
 
 public import NN.Tests.Runtime.Rationals.AutogradEngineTest
 public import NN.Tests.Runtime.Rationals.MlpTest
+public import NN.Tests.Runtime.Rationals.ElementwiseDivTest
 
 /-!
 # Suite
@@ -29,6 +30,7 @@ namespace Suite
 /-- Unified Rational test entrypoint (called by `NN/Tests/Suite.lean`). -/
 def run : IO Unit := do
   Tests.Rationals.AutogradEngine.run
+  Tests.Rationals.ElementwiseDiv.run
   Tests.Rationals.run
 
 end Suite


### PR DESCRIPTION
## What

The CPU eager engine exposed every elementwise op *except* division. The CUDA tape
already has `div` (`NN/Runtime/Autograd/Engine/Cuda/Ops/Elementwise.lean`), but the CPU
`Engine/Core/Elementwise.lean` did not. This adds it:

- **`Tape.div`** — forward `divSpec a b`; backward is the quotient rule
  `∂(a/b)/∂a = 1/b`, `∂(a/b)/∂b = −a/b²`, mirroring the CUDA `div` node. Negation reuses
  `subSpec (fill 0)` exactly as `Tape.sub` does, so no `Neg α` constraint is introduced.
- **`TapeM.div`** — the `StateT` builder wrapper, mirroring `TapeM.mul`.

## Design note

`div` takes `[Context α]` rather than a minimal `[Div α]`, matching the existing
`abs`/`sqrt`/`exp` nodes: its `divSpec` forward rides the carrier's `/`, which
`Spec.Tensor.divSpec` derives from the ambient `[Context α]` (unlike `mulSpec`/`subSpec`,
which carry explicit minimal instances). This keeps the change a pure addition — no
signature churn in `Spec/Core/TensorOps.lean`.

## Test

`NN/Tests/Runtime/Rationals/ElementwiseDivTest.lean` exercises the node over `ℚ`, where
exact rational arithmetic lets it assert the forward value *and* both gradients by exact
equality (no float roundoff): with `a = [6, 8]`, `b = [2, 4]`, `dLdy = [1, 1]` it checks
`y = [3, 2]`, `∂L/∂a = [1/2, 1/4]`, `∂L/∂b = [−3/2, −1/2]`. Registered in the Rationals
suite (`lake exe nn_tests_suite`).

## Verification

Ran `./scripts/checks/check.sh --ci-all`