### PR TITLE
feat(cuda): scope eager device-memory reclamation to the tape (withStep/withForward)

### DIFF
--- a/NN/Runtime/Autograd/Torch/Core/Session.lean
+++ b/NN/Runtime/Autograd/Torch/Core/Session.lean
@@ -370,6 +370,84 @@ def resetTape {α : Type} (s : EagerSession α) : IO Unit := do
   s.nats.set #[]
 
 /--
+Retire the CUDA tape snapshot and side tables and ask the native allocator to return pages.
+
+The caller is responsible for having already released the tape's reclaimable device buffers (via
+`releaseCudaTapeAfterOptimizerStep` or `releaseCudaTapeNonParamValues`); this only drops the now-dead
+tape state so the next step starts clean.
+-/
+def retireCudaTapeState {α : Type} (s : EagerSession α) : IO Unit := do
+  s.cudaTape.set Runtime.Autograd.Cuda.Tape.empty
+  s.paramsByLeaf.set (Std.HashMap.emptyWithCapacity)
+  s.nats.set #[]
+  collectCudaAllocator
+
+/--
+Run one eager training step inside a device-memory scope.
+
+`resetTape` opens the scope; `body` builds the forward tape, runs backward, and applies the optimizer
+(which writes each trainable parameter to a *fresh* persistent mirror); on exit every tape-owned
+temporary is released and the tape snapshot retired, so the device working set stays flat across
+steps regardless of step count.
+
+This is the safe, tape-scoped replacement for a device arena: reclamation is keyed on **tape
+membership**, not allocation epoch. The only buffers it releases are tape node values and workspace
+(`cleanup`), which are runtime-private — callers hold `TensorRef`/`Param`, never a raw `Buffer` — so
+it can never free a buffer the caller still holds. Persistent parameter mirrors are preserved by the
+`paramsByLeaf` role check.
+
+Exception-safe: if `body` raises before the optimizer completes, the parameters may still be their
+live mirrors, so the scope falls back to `releaseCudaTapeNonParamValues` (which preserves *all*
+parameter values) before re-raising — it never frees a live mirror on the error path.
+-/
+def withStep {α : Type} (s : EagerSession α) (body : IO Unit) : IO Unit := do
+  s.resetTape
+  try
+    body
+    -- Success: the optimizer has re-materialized trainable parameters into fresh mirrors, so the
+    -- leaf buffers captured on the just-consumed tape are stale and can be reclaimed too.
+    if s.opts.usesCuda then
+      releaseCudaTapeAfterOptimizerStep s
+      retireCudaTapeState s
+  catch e =>
+    -- Failure: the optimizer may not have run, so trainable leaves may still be the live parameter
+    -- mirrors. Use the conservative release that preserves every parameter value.
+    if s.opts.usesCuda then
+      releaseCudaTapeNonParamValues s
+      retireCudaTapeState s
+    throw e
+
+/--
+Run one eager forward pass inside a device-memory scope.
+
+`resetTape` opens the scope; `body` builds the forward tape and returns a result (typically a
+`TensorRef`); `transfer` copies the survivors off-device — e.g. `EagerSession.getValue`, which
+downloads to a host `Tensor` — *before* the scope releases every forward temporary and retires the
+tape. Persistent parameter mirrors are preserved (`releaseCudaTapeNonParamValues`), so a session can
+run an unbounded sequence of forward passes with a flat device working set.
+
+This is the safe, tape-scoped replacement for `withCudaArena` on the inference/eval path. Because
+`transfer` runs first, the caller leaves the scope holding host tensors, not device `Buffer`s, so the
+release can never invalidate a buffer the caller still references. Exception-safe: the tape is
+reclaimed even if `body` or `transfer` raises.
+-/
+def withForward {α β γ : Type} (s : EagerSession α)
+    (transfer : β → IO γ) (body : IO β) : IO γ := do
+  s.resetTape
+  try
+    let b ← body
+    let out ← transfer b
+    if s.opts.usesCuda then
+      releaseCudaTapeNonParamValues s
+      retireCudaTapeState s
+    pure out
+  catch e =>
+    if s.opts.usesCuda then
+      releaseCudaTapeNonParamValues s
+      retireCudaTapeState s
+    throw e
+
+/--
 Create a mutable parameter object (not yet on the tape).
 
 To record this parameter on the session tape, call `use`, which reads the parameter and records it

--- a/NN/Runtime/Autograd/Torch/Core/Trainer.lean
+++ b/NN/Runtime/Autograd/Torch/Core/Trainer.lean
@@ -686,20 +686,18 @@ def scalarTrainer {α : Type} [Context α] [Internal.CudaBridge.TensorConv α] [
         let step (lr : α) : Curried.Fn α inputShapes (IO Unit) :=
           Curried.curry (α := α) (ss := inputShapes) (β := IO Unit) (fun xs => do
             if opts.usesCuda then
-              sess.resetTape
-              let lossRef ← (do
-                let pRefs ← Internal.useParams (α := α) (ss := paramShapes) ps
-                let xRefs ← Internal.useInputs (α := α) (ss := inputShapes) xs
-                let allRefs := RefList.append (ss₁ := paramShapes) (ss₂ := inputShapes) pRefs xRefs
-                CurriedRef.uncurry (ss := paramShapes ++ inputShapes) (lossEager) allRefs) |>.run sess
-              let gradsDev ← Internal.EagerSession.backwardScalarParamGradsCuda (α := α) sess lossRef
-              Internal.EagerSession.sgdStepAllCudaMap (α := α) sess lr gradsDev
-              Internal.EagerSession.releaseCudaGradMap gradsDev
-              Internal.EagerSession.releaseCudaTapeAfterOptimizerStep sess
-              sess.cudaTape.set Runtime.Autograd.Cuda.Tape.empty
-              sess.paramsByLeaf.set (Std.HashMap.emptyWithCapacity)
-              sess.nats.set #[]
-              Internal.EagerSession.collectCudaAllocator
+              -- One eager training step in a tape-scoped device-memory bracket: `withStep` opens with
+              -- `resetTape`, and on exit releases every tape-owned temporary and retires the snapshot,
+              -- so the device working set stays flat across steps. See `EagerSession.withStep`.
+              sess.withStep do
+                let lossRef ← (do
+                  let pRefs ← Internal.useParams (α := α) (ss := paramShapes) ps
+                  let xRefs ← Internal.useInputs (α := α) (ss := inputShapes) xs
+                  let allRefs := RefList.append (ss₁ := paramShapes) (ss₂ := inputShapes) pRefs xRefs
+                  CurriedRef.uncurry (ss := paramShapes ++ inputShapes) (lossEager) allRefs) |>.run sess
+                let gradsDev ← Internal.EagerSession.backwardScalarParamGradsCuda (α := α) sess lossRef
+                Internal.EagerSession.sgdStepAllCudaMap (α := α) sess lr gradsDev
+                Internal.EagerSession.releaseCudaGradMap gradsDev
             else
               let g ← Curried.uncurry (α := α) (ss := inputShapes) (β := IO (TList α paramShapes))
                 backward xs
@@ -708,42 +706,32 @@ def scalarTrainer {α : Type} [Context α] [Internal.CudaBridge.TensorConv α] [
           if opts.usesCuda then
             some (fun lr beta1 beta2 epsilon =>
               Curried.curry (α := α) (ss := inputShapes) (β := IO Unit) (fun xs => do
-                sess.resetTape
-                let lossRef ← (do
-                  let pRefs ← Internal.useParams (α := α) (ss := paramShapes) ps
-                  let xRefs ← Internal.useInputs (α := α) (ss := inputShapes) xs
-                  let allRefs := RefList.append (ss₁ := paramShapes) (ss₂ := inputShapes) pRefs xRefs
-                  CurriedRef.uncurry (ss := paramShapes ++ inputShapes) (lossEager) allRefs) |>.run sess
-                let gradsDev ← Internal.EagerSession.backwardScalarParamGradsCuda (α := α) sess lossRef
-                Internal.EagerSession.adamStepAllCudaMap (α := α) sess adamStateRef lr beta1 beta2
-                  epsilon gradsDev
-                Internal.EagerSession.releaseCudaGradMap gradsDev
-                Internal.EagerSession.releaseCudaTapeAfterOptimizerStep sess
-                sess.cudaTape.set Runtime.Autograd.Cuda.Tape.empty
-                sess.paramsByLeaf.set (Std.HashMap.emptyWithCapacity)
-                sess.nats.set #[]
-                Internal.EagerSession.collectCudaAllocator))
+                sess.withStep do
+                  let lossRef ← (do
+                    let pRefs ← Internal.useParams (α := α) (ss := paramShapes) ps
+                    let xRefs ← Internal.useInputs (α := α) (ss := inputShapes) xs
+                    let allRefs := RefList.append (ss₁ := paramShapes) (ss₂ := inputShapes) pRefs xRefs
+                    CurriedRef.uncurry (ss := paramShapes ++ inputShapes) (lossEager) allRefs) |>.run sess
+                  let gradsDev ← Internal.EagerSession.backwardScalarParamGradsCuda (α := α) sess lossRef
+                  Internal.EagerSession.adamStepAllCudaMap (α := α) sess adamStateRef lr beta1 beta2
+                    epsilon gradsDev
+                  Internal.EagerSession.releaseCudaGradMap gradsDev))
           else
             none
         let adamWStep? : Option (α → α → α → α → α → Curried.Fn α inputShapes (IO Unit)) :=
           if opts.usesCuda then
             some (fun lr weightDecay beta1 beta2 epsilon =>
               Curried.curry (α := α) (ss := inputShapes) (β := IO Unit) (fun xs => do
-                sess.resetTape
-                let lossRef ← (do
-                let pRefs ← Internal.useParams (α := α) (ss := paramShapes) ps
-                let xRefs ← Internal.useInputs (α := α) (ss := inputShapes) xs
-                let allRefs := RefList.append (ss₁ := paramShapes) (ss₂ := inputShapes) pRefs xRefs
-                CurriedRef.uncurry (ss := paramShapes ++ inputShapes) (lossEager) allRefs) |>.run sess
-                let gradsDev ← Internal.EagerSession.backwardScalarParamGradsCuda (α := α) sess lossRef
-                Internal.EagerSession.adamWStepAllCudaMap (α := α) sess adamStateRef lr weightDecay
-                  beta1 beta2 epsilon gradsDev
-                Internal.EagerSession.releaseCudaGradMap gradsDev
-                Internal.EagerSession.releaseCudaTapeAfterOptimizerStep sess
-                sess.cudaTape.set Runtime.Autograd.Cuda.Tape.empty
-                sess.paramsByLeaf.set (Std.HashMap.emptyWithCapacity)
-                sess.nats.set #[]
-                Internal.EagerSession.collectCudaAllocator))
+                sess.withStep do
+                  let lossRef ← (do
+                  let pRefs ← Internal.useParams (α := α) (ss := paramShapes) ps
+                  let xRefs ← Internal.useInputs (α := α) (ss := inputShapes) xs
+                  let allRefs := RefList.append (ss₁ := paramShapes) (ss₂ := inputShapes) pRefs xRefs
+                  CurriedRef.uncurry (ss := paramShapes ++ inputShapes) (lossEager) allRefs) |>.run sess
+                  let gradsDev ← Internal.EagerSession.backwardScalarParamGradsCuda (α := α) sess lossRef
+                  Internal.EagerSession.adamWStepAllCudaMap (α := α) sess adamStateRef lr weightDecay
+                    beta1 beta2 epsilon gradsDev
+                  Internal.EagerSession.releaseCudaGradMap gradsDev))
           else
             none
         pure

--- a/NN/Tests/Runtime/Cuda/Stress.lean
+++ b/NN/Tests/Runtime/Cuda/Stress.lean
@@ -10,6 +10,7 @@ public import NN.Runtime.Autograd.Engine.Cuda.Buffer
 public import NN.Runtime.Autograd.Engine.Cuda.Ops
 public import NN.Runtime.Autograd.Engine.FastKernels
 public import NN.Runtime.Autograd.TorchLean.Random
+public import NN.Runtime.Autograd.Torch.Core.Session
 public import NN.Entrypoint.Tensor
 public import NN.Tests.Runtime.Cuda.Utils
 
@@ -36,6 +37,7 @@ namespace Stress
 open Runtime.Autograd
 open Runtime.Autograd.Cuda
 open Runtime.Autograd.TorchLean
+open Runtime.Autograd.Torch.Internal (EagerSession)
 open Spec
 open Tensor
 
@@ -233,10 +235,132 @@ def runMatmulStress : IO Unit := do
   Utils.assertTensorApprox (s := sY2) "matmul stress case2 fp32" yFp322 yRef2 (tol := 7e-3)
   Utils.assertTensorApprox (s := sY2) "matmul stress case2 fp64" yFp642 yRef2 (tol := 1e-9)
 
+/--
+One eager Buffer workload step for the leak-bound stress: allocate a short chain of device buffers,
+then free every one through the explicit `Buffer.release` discipline that long CUDA loops use so they
+do not wait on external-object finalizers. Returns the number of live allocations freed (the sum of
+the release return codes), which also confirms each free found a live allocation and keeps Lean from
+eliminating the release calls as dead code.
+-/
+def leakStep (n : UInt32) : IO Nat := do
+  let a := Buffer.full n 1.5
+  let b := Buffer.full n (-0.5)
+  let c := Buffer.add a b
+  let d := Buffer.mul c a
+  let s := Buffer.reduceSum d
+  let freed :=
+    Buffer.release a + Buffer.release b + Buffer.release c + Buffer.release d + Buffer.release s
+  return freed.toNat
+
+/--
+Leak-bound allocator stress. Drives a small eager Buffer workload through the explicit `Buffer.release`
+discipline for two equal blocks of steps and asserts the device working set is bounded independent of
+step count, using the allocator telemetry (`Buffer.allocatorStats`):
+
+  - each step freed exactly its allocations (the release calls fired and were not dropped as dead
+    code);
+  - net live allocations and live bytes after 2× the steps match the 1× snapshot (the leak-bound
+    invariant);
+  - with every buffer released the loop returns to the baseline working set.
+
+Runs on the CPU stub through the shared allocator-counter parity.
+-/
+def runLeakBoundStress : IO Unit := do
+  IO.println "== allocator leak-bound stress =="
+  let n : UInt32 := 4096
+  let releasesPerStep : Nat := 5
+  let block : Nat := 128
+  let base ← Buffer.allocatorStats
+  IO.println s!"  baseline:        {base.format}"
+  let mut freed1 : Nat := 0
+  for _ in [0:block] do
+    freed1 := freed1 + (← leakStep n)
+  let afterK ← Buffer.allocatorStatsWithToken (UInt32.ofNat block)
+  IO.println s!"  after {block} steps:  {afterK.format}"
+  let mut freed2 : Nat := 0
+  for _ in [0:block] do
+    freed2 := freed2 + (← leakStep n)
+  let after2K ← Buffer.allocatorStatsWithToken (UInt32.ofNat (2 * block))
+  IO.println s!"  after {2 * block} steps:  {after2K.format}"
+  let expectedFreed := releasesPerStep * block
+  if freed1 != expectedFreed then
+    throw <| IO.userError s!"leak-bound: first block freed {freed1}, expected {expectedFreed}"
+  if freed2 != expectedFreed then
+    throw <| IO.userError s!"leak-bound: second block freed {freed2}, expected {expectedFreed}"
+  let netK : UInt64 := afterK.allocCount - afterK.freeCount
+  let net2K : UInt64 := after2K.allocCount - after2K.freeCount
+  if net2K != netK then
+    throw <| IO.userError s!"leak-bound: net live allocations grew with step count ({netK} → {net2K})"
+  if after2K.liveBytes != afterK.liveBytes then
+    throw <| IO.userError
+      s!"leak-bound: live bytes grew with step count ({afterK.liveBytes} → {after2K.liveBytes})"
+  let netBase : UInt64 := base.allocCount - base.freeCount
+  if netK != netBase then
+    throw <| IO.userError
+      s!"leak-bound: live allocations did not return to baseline ({netBase} → {netK})"
+
+/--
+Eager-session `withForward` scope stress — the safe, tape-scoped replacement for the rejected device
+arena.
+
+*Part 1* (every build, including the CPU stub): a functional check that `withForward` runs the body,
+copies the result off the tape via `getValue`, and returns it.
+
+*Part 2* (real CUDA only — a `.cuda` session is rejected on the CPU-stub build, so it is skipped
+there): run many forward scopes on a CUDA session, each allocating device buffers, and assert via the
+allocator telemetry that the device working set is flat across step count and returns to baseline.
+This is the arena's motivating case (a long eager loop that would otherwise accrete device memory),
+now bounded through *tape membership* — `withForward` frees only tape-owned temporaries and never a
+buffer the caller still holds.
+-/
+def runEagerScopeStress : IO Unit := do
+  IO.println "== eager-session withForward scope stress =="
+  let sh : Shape := shape![4]
+  let v : Tensor Float sh := tensorND! [4] [1.0, 2.0, 3.0, 4.0]
+  -- Part 1: functional check on a CPU session (runs everywhere).
+  let sessCpu ← EagerSession.new (α := Float) {}
+  let outCpu ← sessCpu.withForward
+    (transfer := fun r => EagerSession.getValue (α := Float) sessCpu (sh := sh) r)
+    (body := EagerSession.const (α := Float) sessCpu (sh := sh) v)
+  Utils.assertTensorApprox (s := sh) "withForward returns the transferred body result" outCpu v
+  IO.println "  cpu session: withForward runs body + transfer ✓"
+  -- Part 2: device-memory leak-bound loop on a real CUDA session.
+  match Buffer.runtimeStatus with
+  | .nativeAvailable =>
+      let sess ← EagerSession.new (α := Float) { requestedDevice := .cuda }
+      let block : Nat := 128
+      let stepScope : IO Unit := do
+        let _ ← sess.withForward
+          (transfer := fun r => EagerSession.getValue (α := Float) sess (sh := sh) r)
+          (body := EagerSession.const (α := Float) sess (sh := sh) v)
+        pure ()
+      let base ← Buffer.allocatorStats
+      for _ in [0:block] do stepScope
+      let afterK ← Buffer.allocatorStatsWithToken (UInt32.ofNat block)
+      for _ in [0:block] do stepScope
+      let after2K ← Buffer.allocatorStatsWithToken (UInt32.ofNat (2 * block))
+      let netBase : UInt64 := base.allocCount - base.freeCount
+      let netK : UInt64 := afterK.allocCount - afterK.freeCount
+      let net2K : UInt64 := after2K.allocCount - after2K.freeCount
+      if net2K != netK then
+        throw <| IO.userError
+          s!"withForward scope: live allocations grew with step count ({netK} → {net2K})"
+      if after2K.liveBytes != afterK.liveBytes then
+        throw <| IO.userError
+          s!"withForward scope: live bytes grew with step count ({afterK.liveBytes} → {after2K.liveBytes})"
+      if netK != netBase then
+        throw <| IO.userError
+          s!"withForward scope: working set did not return to baseline ({netBase} → {netK})"
+      IO.println "  cuda session: device working set flat across forward scopes ✓"
+  | _ =>
+      IO.println "  cuda leak-bound loop skipped (no native CUDA device on this build)"
+
 def run : IO Unit := do
   IO.println "=== CUDA runtime stress suite ==="
   runRngStress
   runReleaseStress
+  runLeakBoundStress
+  runEagerScopeStress
   runGradientAliasingStress
   runLargeBufferStress
   runMatmulStress


### PR DESCRIPTION
## Summary

Reworked in response to the review here: instead of a public device **arena** that frees buffers by
allocation epoch — which can free a device buffer while its Lean `Buffer` is still reachable
(use-after-free if a value or alias is missing from `keep`) — scoped device-memory reclamation now
lives **inside the eager session/tape ownership model**, keyed on **tape membership**.

Two exception-safe combinators on `EagerSession` bracket an eager phase and reclaim the tape at its
boundary:

- **`withStep`** — one training step. `resetTape` opens it; the body runs forward/backward/optimizer;
  on exit every tape-owned temporary is released and the tape snapshot retired, so the device working
  set stays flat across steps.
- **`withForward`** — one inference/eval forward pass. It transfers the body's result off the tape
  (e.g. `getValue`, which downloads to host) **before** releasing the forward temporaries.

The three open-coded CUDA optimizer-step reclamation sites in `Trainer` now use `withStep`.

## Why this is safe (addresses the arena's use-after-free)

Reclamation is keyed on **tape membership**, not allocation epoch. The only buffers a scope frees are
tape node `value`s and workspace (`cleanup`) — which are **runtime-private**: callers hold
`TensorRef`/`Param` handles, never a raw `Buffer`. So a scope can never invalidate a buffer the caller
still holds. Persistent parameter mirrors are preserved by the `paramsByLeaf` role check.

`withStep` is also correct on the error path: if the body raises **before** the optimizer re-mirrors
the parameters, the trainable leaf buffers may still be the live mirrors, so it falls back to the
conservative release (`releaseCudaTapeNonParamValues`, which preserves *every* parameter value) before
re-raising — it never frees a live mirror.

This removes the class of hazard that blocked the public `withCudaArena` API; the arena implementation
(`torchlean_cuda_arena.h`, the epoch registry, the buffer `arena_reg` field, the UAF detector) is
dropped.

## Scope vs. the original problem

The refactored `main` already bounds the **training** path (each optimizer step releases the tape);
this generalizes that into a reusable, exception-safe scope and gives the **inference/eval** path the
same guarantee. The one case the arena uniquely served — a raw `foldl` of `Buffer → Buffer` with no
tape and no IO — is intentionally out of scope: real models go through the tape, and for a genuine
in-op reduction the existing `releaseThen`/`releaseManyThen` (threaded through the carried result) is
the safe tool.

## Tests

`NN/Tests/Runtime/Cuda/Stress.lean` (in `nn_tests_suite`, wired into the stress suite):

- **`runLeakBoundStress`** (folded from the closed leak-bound regression): drives a small eager Buffer
  workload through the explicit release discipline for two equal blocks of steps and asserts, via
  `Buffer.allocatorStats`, that live allocations and live bytes are flat across step count and return
  to baseline. Runs on the **CPU stub**.
- **`runEagerScopeStress`**: checks `withForward` end-to-end on a CPU session (every build), and — on a
  real CUDA session — that the device working set is flat across forward scopes and returns to
  baseline. The CUDA loop is **skipped on the CPU-stub build**, which rejects `.cuda` sessions.

## Verification

CPU-stub `lake build && lake exe nn_tests_suite && lake lint`: green. The CUDA-specific assertions
(`runEagerScopeStress` Part 2) require a GPU — run `scripts/checks/check.sh --cuda`.
