### PR TITLE
feat(cuda): bound the device block reuse cache with an env byte cap

### DIFF
--- a/NN/Runtime/Autograd/Engine/Cuda/Buffer.lean
+++ b/NN/Runtime/Autograd/Engine/Cuda/Buffer.lean
@@ -132,6 +132,9 @@ opaque allocatorDeviceFreeBytesRaw (u : UInt32) : UInt64
 @[extern "torchlean_cuda_allocator_device_total_bytes"]
 opaque allocatorDeviceTotalBytesRaw (u : UInt32) : UInt64
 
+@[extern "torchlean_cuda_allocator_cache_bytes"]
+opaque allocatorCacheBytesRaw (u : UInt32) : UInt64
+
 /--
 Snapshot of the CUDA buffer allocator.
 
@@ -141,6 +144,10 @@ counters track the Lean external objects that own those payloads; in a steady wo
 `deviceTotalBytes` come from `cudaMemGetInfo` in the CUDA build and are `0` in the CPU stub.
 Together these fields distinguish payload leaks, wrapper-lifetime leaks, and broader CUDA memory
 pressure or fragmentation.
+
+`cacheBytes` is the device memory held in the buffer reuse cache — dropped buffers awaiting reuse,
+which are *not* counted in `liveBytes`. `TORCHLEAN_CUDA_CACHE_CAP_BYTES` bounds it; it is always `0`
+in the CPU stub, which keeps no cache.
 -/
 structure AllocatorStats where
   liveBytes : UInt64
@@ -153,6 +160,7 @@ structure AllocatorStats where
   wrapperFinalizeCount : UInt64
   deviceFreeBytes : UInt64
   deviceTotalBytes : UInt64
+  cacheBytes : UInt64
 deriving Repr
 
 /--
@@ -173,7 +181,8 @@ def allocatorStatsWithToken (token : UInt32) : IO AllocatorStats := do
       wrapperAllocCount := wrapperAllocCountRaw token
       wrapperFinalizeCount := wrapperFinalizeCountRaw token
       deviceFreeBytes := allocatorDeviceFreeBytesRaw token
-      deviceTotalBytes := allocatorDeviceTotalBytesRaw token }
+      deviceTotalBytes := allocatorDeviceTotalBytesRaw token
+      cacheBytes := allocatorCacheBytesRaw token }
 
 /-- Read the current CUDA allocator counters. Prefer `allocatorStatsWithToken` in repeated loops. -/
 def allocatorStats : IO AllocatorStats :=
@@ -195,7 +204,8 @@ def AllocatorStats.format (s : AllocatorStats) : String :=
   " wrappers_alloc=" ++ toString s.wrapperAllocCount ++
   " wrappers_finalized=" ++ toString s.wrapperFinalizeCount ++
   " cuda_free=" ++ mibString s.deviceFreeBytes ++
-  " cuda_total=" ++ mibString s.deviceTotalBytes
+  " cuda_total=" ++ mibString s.deviceTotalBytes ++
+  " cache=" ++ mibString s.cacheBytes
 
 /--
 Create a device buffer by copying from a host `FloatArray` (casts each element to float32).

--- a/NN/Tests/Runtime/Cuda/Stress.lean
+++ b/NN/Tests/Runtime/Cuda/Stress.lean
@@ -434,14 +434,20 @@ the 1 MiB cap. It then reads `cacheBytes` from the allocator telemetry and asser
 * **on CUDA, capped** — the cap is the *binding* constraint: the workload exceeds it, yet the cache
   filled to within one block of it (`block ≤ cacheBytes` and `cacheBytes + block > cap`) rather than
   growing to the full 8 MiB;
-* **on CUDA, control** (`cap = 0`, unset) — every returned block stays cached
-  (`cacheBytes = totalReturned`): the unbounded growth the cap exists to bound.
+* **on CUDA, control** (`cap = 0`, unset, or a malformed/overflowing value the strict native
+  parser rejects) — every returned block stays cached (`cacheBytes = totalReturned`): the
+  unbounded growth the cap exists to bound.
 
 Selected in a forked child by `TORCHLEAN_CUDA_CACHE_PROBE=cache-cap` (see `NN.Tests.run`). -/
 def runCacheCapProbe : IO Unit := do
   IO.println "== cuda block-cache byte-cap probe =="
   let capStr ← IO.getEnv "TORCHLEAN_CUDA_CACHE_CAP_BYTES"
-  let capBytes : UInt64 := (capStr.bind (·.toNat?)).map UInt64.ofNat |>.getD 0
+  -- Mirror the native parser's strict semantics: only a digit string that fits the native word is
+  -- a cap; malformed or overflowing values are rejected and leave the cache unbounded (cap 0).
+  let capBytes : UInt64 :=
+    match capStr.bind (·.toNat?) with
+    | some nn => if nn < UInt64.size then UInt64.ofNat nn else 0
+    | none => 0
   let n : UInt32 := 65536                              -- 256 KiB per block (float32)
   let blockBytes : UInt64 := UInt64.ofNat (n.toNat * 4)
   let k : Nat := 32                                    -- 8 MiB of returns, far past a 1 MiB cap
@@ -490,7 +496,12 @@ fixed before the process's first cache operation; the test therefore forks the s
 * **capped** — `TORCHLEAN_CUDA_CACHE_CAP_BYTES=1048576` bounds an 8 MiB return workload to a 1 MiB
   cache;
 * **control** — `TORCHLEAN_CUDA_CACHE_CAP_BYTES=0` (explicitly unbounded), so the same workload
-  caches the full 8 MiB (the unbounded growth the cap fixes).
+  caches the full 8 MiB (the unbounded growth the cap fixes);
+* **malformed** — `TORCHLEAN_CUDA_CACHE_CAP_BYTES=1MiB` is rejected by the strict native parser,
+  so the cache stays unbounded and behaves exactly like the control. This pins the rejection: a
+  prefix-parsing reader would instead take the leading `1` as a one-byte cap and cache nothing;
+* **overflow** — a value past the native word size is likewise rejected rather than truncated or
+  saturated, so the cache again behaves like the control.
 
 Both children pass the cap explicitly, so neither inherits a stray `TORCHLEAN_CUDA_CACHE_CAP_BYTES`
 from the parent environment — in particular the control child is pinned to `0`, not left to inherit
@@ -524,6 +535,20 @@ def runCacheCapTest : IO Unit := do
     throw <| IO.userError
       s!"block-cache cap: control child failed (exit {control.exitCode}); stderr:\n{control.stderr}"
   IO.println "  control: with no cap the full workload is cached, as designed ✓"
+  -- malformed: rejected outright by the strict parser, so the cache stays unbounded. A
+  -- prefix-parsing reader would take the leading "1" as a one-byte cap and cache nothing; the
+  -- child asserts the control (fully cached) outcome instead.
+  let malformed ← fork "1MiB"
+  if malformed.exitCode != 0 then
+    throw <| IO.userError
+      s!"block-cache cap: malformed-value child failed (exit {malformed.exitCode}); stderr:\n{malformed.stderr}"
+  IO.println "  malformed: non-numeric cap rejected, cache stays unbounded ✓"
+  -- overflow: past the native word, rejected rather than truncated or saturated.
+  let overflow ← fork "99999999999999999999999999"
+  if overflow.exitCode != 0 then
+    throw <| IO.userError
+      s!"block-cache cap: overflow-value child failed (exit {overflow.exitCode}); stderr:\n{overflow.stderr}"
+  IO.println "  overflow: oversized cap rejected, cache stays unbounded ✓"
 
 def run : IO Unit := do
   IO.println "=== CUDA runtime stress suite ==="

--- a/NN/Tests/Runtime/Cuda/Stress.lean
+++ b/NN/Tests/Runtime/Cuda/Stress.lean
@@ -407,11 +407,130 @@ def runMatmulStress : IO Unit := do
   Utils.assertTensorApprox (s := sY2) "matmul stress case2 fp32" yFp322 yRef2 (tol := 7e-3)
   Utils.assertTensorApprox (s := sY2) "matmul stress case2 fp64" yFp642 yRef2 (tol := 1e-9)
 
+/--
+Build `k` freshly-allocated device buffers of length `n`, returned together with the total element
+count touched. Reading the sizes back forces the allocations so Lean cannot drop them as dead code;
+`salt` varies the fill value between callers so repeated blocks are distinguishable. -/
+def buildCacheScratch (n : UInt32) (k : Nat) (salt : Nat) : Array Buffer × Nat :=
+  Id.run do
+    let mut held : Array Buffer := Array.mkEmpty k
+    for i in [0:k] do
+      held := held.push (Buffer.full n (1.0 + Float.ofNat (salt * k + i)))
+    let mut touched : Nat := 0
+    for b in held do
+      touched := touched + (Buffer.size b).toNat
+    return (held, touched)
+
+/--
+Block-cache byte-cap probe, the subject of `runCacheCapTest`. Runs in a forked child so the cap
+(`TORCHLEAN_CUDA_CACHE_CAP_BYTES`, read once natively) is fixed before the first cache operation.
+
+The child allocates `k` same-size blocks (the cache starts empty, so each is a fresh device alloc),
+then returns them all to the cache via `Buffer.release`. The total returned (8 MiB here) far exceeds
+the 1 MiB cap. It then reads `cacheBytes` from the allocator telemetry and asserts:
+
+* **always** (both backends) — `cacheBytes ≤ cap`: the cap is enforced (the CPU stub holds no cache,
+  so `cacheBytes = 0 ≤ cap` trivially);
+* **on CUDA, capped** — the cap is the *binding* constraint: the workload exceeds it, yet the cache
+  filled to within one block of it (`block ≤ cacheBytes` and `cacheBytes + block > cap`) rather than
+  growing to the full 8 MiB;
+* **on CUDA, control** (`cap = 0`, unset) — every returned block stays cached
+  (`cacheBytes = totalReturned`): the unbounded growth the cap exists to bound.
+
+Selected in a forked child by `TORCHLEAN_CUDA_CACHE_PROBE=cache-cap` (see `NN.Tests.run`). -/
+def runCacheCapProbe : IO Unit := do
+  IO.println "== cuda block-cache byte-cap probe =="
+  let capStr ← IO.getEnv "TORCHLEAN_CUDA_CACHE_CAP_BYTES"
+  let capBytes : UInt64 := (capStr.bind (·.toNat?)).map UInt64.ofNat |>.getD 0
+  let n : UInt32 := 65536                              -- 256 KiB per block (float32)
+  let blockBytes : UInt64 := UInt64.ofNat (n.toNat * 4)
+  let k : Nat := 32                                    -- 8 MiB of returns, far past a 1 MiB cap
+  let totalBytes : UInt64 := UInt64.ofNat (n.toNat * 4 * k)
+  let pre ← Buffer.allocatorStats
+  -- `deviceTotalBytes` comes from `cudaMemGetInfo`: nonzero on the CUDA build, 0 on the CPU stub.
+  let onCuda : Bool := pre.deviceTotalBytes != 0
+  -- Fresh child: the cache starts empty, so every block is a real device alloc, not a cache reuse.
+  let (held, touched) := buildCacheScratch n k 1
+  if touched != k * n.toNat then
+    throw <| IO.userError "cache-cap probe: scratch build under-allocated"
+  -- Return every block to the cache. Under the cap, returns past the cap free instead of caching.
+  let mut freed : Nat := 0
+  for b in held do
+    freed := freed + (Buffer.release b).toNat
+  if freed != k then
+    throw <| IO.userError s!"cache-cap probe: expected {k} releases, got {freed}"
+  let post ← Buffer.allocatorStats
+  IO.println s!"  cap={capBytes} returned={totalBytes} cacheBytes={post.cacheBytes} cuda={onCuda}"
+  if capBytes == 0 then
+    -- Control: no cap, so every returned block stays cached — the growth the cap bounds.
+    if onCuda && post.cacheBytes != totalBytes then
+      throw <| IO.userError
+        s!"cache-cap probe (control): uncapped cache held {post.cacheBytes}, expected {totalBytes}"
+  else
+    -- The cap is enforced on every backend (the stub keeps no cache, so cacheBytes = 0 ≤ cap).
+    if post.cacheBytes > capBytes then
+      throw <| IO.userError s!"cache-cap probe: cache exceeded cap ({post.cacheBytes} > {capBytes})"
+    if onCuda then
+      -- On CUDA the cap is the binding constraint: the workload exceeds it, yet the cache filled to
+      -- within one block of the cap instead of to the full 8 MiB.
+      if totalBytes ≤ capBytes then
+        throw <| IO.userError "cache-cap probe: workload did not exceed the cap (test misconfigured)"
+      if post.cacheBytes < blockBytes then
+        throw <| IO.userError s!"cache-cap probe: cache did not fill ({post.cacheBytes} < {blockBytes})"
+      if post.cacheBytes + blockBytes ≤ capBytes then
+        throw <| IO.userError
+          s!"cache-cap probe: cache under-filled below the cap ({post.cacheBytes} + {blockBytes} ≤ {capBytes})"
+  IO.println "  block-cache byte cap enforced ✓"
+
+/--
+Regression test for the device block-cache byte cap. The cap is read once natively, so it must be
+fixed before the process's first cache operation; the test therefore forks the suite binary
+(`/proc/self/exe`) per configuration (see `runCacheCapProbe`):
+
+* **capped** — `TORCHLEAN_CUDA_CACHE_CAP_BYTES=1048576` bounds an 8 MiB return workload to a 1 MiB
+  cache;
+* **control** — `TORCHLEAN_CUDA_CACHE_CAP_BYTES=0` (explicitly unbounded), so the same workload
+  caches the full 8 MiB (the unbounded growth the cap fixes).
+
+Both children pass the cap explicitly, so neither inherits a stray `TORCHLEAN_CUDA_CACHE_CAP_BYTES`
+from the parent environment — in particular the control child is pinned to `0`, not left to inherit
+a cap that would mask the uncapped-growth it is meant to observe.
+
+Both children assert internally and exit non-zero on failure. Linux-only (uses `/proc/self/exe`). -/
+def runCacheCapTest : IO Unit := do
+  IO.println "== cuda block-cache byte-cap (fork test) =="
+  let self : System.FilePath := "/proc/self/exe"
+  if !(← self.pathExists) then
+    IO.println "  skipped: no /proc/self/exe (fork test is Linux-only)"
+    return
+  -- Always set the cap explicitly in the child's environment so it never inherits the parent's
+  -- `TORCHLEAN_CUDA_CACHE_CAP_BYTES`; the control run pins it to "0" (unbounded) rather than unset.
+  let fork (cap : String) : IO IO.Process.Output := do
+    let env := #[
+      ("TORCHLEAN_CUDA_CACHE_PROBE", some "cache-cap"),
+      ("TORCHLEAN_CUDA_CACHE_CAP_BYTES", some cap)
+    ]
+    IO.Process.output { cmd := self.toString, args := #[], env := env }
+  -- capped: a 1 MiB cap bounds 8 MiB of returns.
+  let capped ← fork "1048576"
+  if capped.exitCode != 0 then
+    throw <| IO.userError
+      s!"block-cache cap: capped child failed (exit {capped.exitCode}); stderr:\n{capped.stderr}"
+  IO.println "  capped: 8 MiB of returns bounded to a 1 MiB cache ✓"
+  -- control: cap explicitly 0 (unbounded), so the same returns all stay cached, the behaviour the
+  -- cap exists to bound; the explicit 0 keeps a parent-set cap from masking it.
+  let control ← fork "0"
+  if control.exitCode != 0 then
+    throw <| IO.userError
+      s!"block-cache cap: control child failed (exit {control.exitCode}); stderr:\n{control.stderr}"
+  IO.println "  control: with no cap the full workload is cached, as designed ✓"
+
 def run : IO Unit := do
   IO.println "=== CUDA runtime stress suite ==="
   runRngStress
   runReleaseStress
   runWrapperLifetimeStress
+  runCacheCapTest
   runGradientAliasingStress
   runMalformedBufferValidationStress
   runDisconnectedDenseGradientStress

--- a/NN/Tests/Suite.lean
+++ b/NN/Tests/Suite.lean
@@ -46,15 +46,21 @@ def usage : String :=
     ]
 
 def run : IO Unit := do
-  IO.println "== TorchLean: curated tests =="
-  NN.Tests.API.SelfSupervised.BlockMask.run
-  NN.Tests.API.GradientAccumulation.run
-  NN.Tests.Backend.Profile.run
-  NN.Tests.MLTheory.CROWNOperators.run
-  Tests.Floats.run
-  Tests.Rationals.Suite.run
-  Tests.Cuda.run
-  IO.println "== TorchLean: all curated tests passed =="
+  -- Fork-child mode for the block-cache byte cap. A child launched by
+  -- `Tests.Cuda.Stress.runCacheCapTest` re-enters here with the cap fixed in its environment and
+  -- runs only the cache probe, then exits, so the parent can inspect the outcome.
+  match ← IO.getEnv "TORCHLEAN_CUDA_CACHE_PROBE" with
+  | some "cache-cap" => Tests.Cuda.Stress.runCacheCapProbe
+  | _ =>
+    IO.println "== TorchLean: curated tests =="
+    NN.Tests.API.SelfSupervised.BlockMask.run
+    NN.Tests.API.GradientAccumulation.run
+    NN.Tests.Backend.Profile.run
+    NN.Tests.MLTheory.CROWNOperators.run
+    Tests.Floats.run
+    Tests.Rationals.Suite.run
+    Tests.Cuda.run
+    IO.println "== TorchLean: all curated tests passed =="
 
 def main (args : List String) : IO Unit := do
   match args with

--- a/csrc/cuda/tensor/torchlean_cuda_tensor.cu
+++ b/csrc/cuda/tensor/torchlean_cuda_tensor.cu
@@ -90,7 +90,9 @@ static size_t g_torchlean_cuda_cache_bytes = 0;
 // Optional byte cap on the reuse cache, read once from the environment.
 // `TORCHLEAN_CUDA_CACHE_CAP_BYTES` is the maximum total bytes the cache may hold; 0 (the default)
 // leaves it unbounded, preserving the prior behaviour exactly. When set, a returned block that would
-// grow the cache past the cap is freed immediately instead of cached.
+// grow the cache past the cap is freed immediately instead of cached. The value must be a plain
+// decimal byte count; a malformed or overflowing value is rejected with a warning and leaves the
+// cache unbounded, rather than being silently misread as some other cap.
 //
 // The environment is read exactly once, under `pthread_once`, so concurrent first callers cannot
 // race on the parse: the initializer runs on a single thread while the others block, and the value
@@ -99,9 +101,40 @@ static size_t g_torchlean_cuda_cache_bytes = 0;
 static size_t g_torchlean_cuda_cache_cap_value = 0;
 static pthread_once_t g_torchlean_cuda_cache_cap_once = PTHREAD_ONCE_INIT;
 
+// Strict decimal parser for the cap: accepts exactly a non-empty digit string whose value fits
+// in `size_t` — no sign, no whitespace, no base prefix — and reports malformed or overflowing
+// input instead of guessing. A hand-rolled loop rather than `strtoull` also keeps this file free
+// of the glibc >= 2.38 `__isoc23_strtoull` symbol redirection, so the object stays self-contained.
+static bool torchlean_cuda_parse_cache_cap(const char* s, size_t* out) {
+  size_t value = 0;
+  for (const char* p = s; *p; ++p) {
+    if (*p < '0' || *p > '9') {
+      return false;
+    }
+    const size_t digit = (size_t)(*p - '0');
+    if (value > (SIZE_MAX - digit) / 10) {
+      return false;
+    }
+    value = value * 10 + digit;
+  }
+  *out = value;
+  return true;
+}
+
 static void torchlean_cuda_cache_byte_cap_init(void) {
   const char* v = getenv("TORCHLEAN_CUDA_CACHE_CAP_BYTES");
-  g_torchlean_cuda_cache_cap_value = (v && v[0]) ? (size_t)strtoull(v, NULL, 10) : (size_t)0;
+  if (!v || !v[0]) {
+    return;  // unset or empty: the cache stays unbounded (cap 0)
+  }
+  size_t parsed = 0;
+  if (torchlean_cuda_parse_cache_cap(v, &parsed)) {
+    g_torchlean_cuda_cache_cap_value = parsed;
+  } else {
+    fprintf(stderr,
+            "TorchLean CUDA warning: ignoring TORCHLEAN_CUDA_CACHE_CAP_BYTES='%s': "
+            "expected an unsigned decimal byte count; the cache stays unbounded\n",
+            v);
+  }
 }
 
 static size_t torchlean_cuda_cache_byte_cap(void) {

--- a/csrc/cuda/tensor/torchlean_cuda_tensor.cu
+++ b/csrc/cuda/tensor/torchlean_cuda_tensor.cu
@@ -82,6 +82,32 @@ static pthread_mutex_t g_torchlean_cuda_cache_mutex = PTHREAD_MUTEX_INITIALIZER;
 static torchlean_cuda_cached_block* g_torchlean_cuda_cache = nullptr;
 static size_t g_torchlean_cuda_cache_count = 0;
 static size_t g_torchlean_cuda_cache_cap = 0;
+// Total device bytes currently held in the reuse cache (sum of the cached blocks' byte sizes),
+// guarded by `g_torchlean_cuda_cache_mutex`. The cache holds buffers Lean has already dropped, so
+// these bytes are NOT counted in `live_bytes`; left unbounded the cache can grow without limit.
+static size_t g_torchlean_cuda_cache_bytes = 0;
+
+// Optional byte cap on the reuse cache, read once from the environment.
+// `TORCHLEAN_CUDA_CACHE_CAP_BYTES` is the maximum total bytes the cache may hold; 0 (the default)
+// leaves it unbounded, preserving the prior behaviour exactly. When set, a returned block that would
+// grow the cache past the cap is freed immediately instead of cached.
+//
+// The environment is read exactly once, under `pthread_once`, so concurrent first callers cannot
+// race on the parse: the initializer runs on a single thread while the others block, and the value
+// is published before any caller observes it. (A plain function-local static assigned after its
+// declaration would be a data race, and would depend on `-fthreadsafe-statics` being enabled.)
+static size_t g_torchlean_cuda_cache_cap_value = 0;
+static pthread_once_t g_torchlean_cuda_cache_cap_once = PTHREAD_ONCE_INIT;
+
+static void torchlean_cuda_cache_byte_cap_init(void) {
+  const char* v = getenv("TORCHLEAN_CUDA_CACHE_CAP_BYTES");
+  g_torchlean_cuda_cache_cap_value = (v && v[0]) ? (size_t)strtoull(v, NULL, 10) : (size_t)0;
+}
+
+static size_t torchlean_cuda_cache_byte_cap(void) {
+  pthread_once(&g_torchlean_cuda_cache_cap_once, torchlean_cuda_cache_byte_cap_init);
+  return g_torchlean_cuda_cache_cap_value;
+}
 
 // Reuse exact-size buffers only after CUDA has recorded that all earlier work using the block has
 // completed. This lowers allocator pressure during long training loops without forcing a global
@@ -115,6 +141,7 @@ static float* torchlean_cuda_take_cached_block(size_t n) {
                                                "cudaEventDestroy cached buffer reuse failed");
       g_torchlean_cuda_cache[i] = g_torchlean_cuda_cache[g_torchlean_cuda_cache_count - 1];
       g_torchlean_cuda_cache_count--;
+      g_torchlean_cuda_cache_bytes -= (size_t)torchlean_float_bytes_for(n);
       torchlean_cuda_unlock(&g_torchlean_cuda_cache_mutex,
                             "pthread_mutex_unlock buffer cache failed");
       return data;
@@ -149,9 +176,31 @@ static void torchlean_cuda_return_cached_block(size_t n, float* data) {
     torchlean_cuda_free_best_effort(data, "cudaFree uncached buffer after event-record failure failed");
     return;
   }
+  const size_t incoming = (size_t)torchlean_float_bytes_for(n);
+  const size_t cap = torchlean_cuda_cache_byte_cap();
+  bool over_cap = false;
   torchlean_cuda_lock(&g_torchlean_cuda_cache_mutex, "pthread_mutex_lock buffer return failed");
-  torchlean_cuda_cache_push({n, data, ready});
+  // Overflow-safe form of `g_torchlean_cuda_cache_bytes + incoming > cap`: the sum is never formed,
+  // so it cannot wrap `size_t`. A single incoming block larger than the cap trips it directly;
+  // otherwise `cap - incoming` is a well-defined non-negative headroom that the current total must
+  // not exceed.
+  if (cap != 0 &&
+      (incoming > cap || g_torchlean_cuda_cache_bytes > cap - incoming)) {
+    over_cap = true;
+  } else {
+    torchlean_cuda_cache_push({n, data, ready});
+    g_torchlean_cuda_cache_bytes += incoming;
+  }
   torchlean_cuda_unlock(&g_torchlean_cuda_cache_mutex, "pthread_mutex_unlock buffer return failed");
+  if (over_cap) {
+    // Caching this block would grow the process-global cache past the byte cap, so free it now
+    // instead. The just-recorded event signals when pending work on the block completes; wait on it
+    // before releasing the device memory, exactly as the flush path does, so an in-flight kernel
+    // never reads freed memory.
+    torchlean_cuda_synchronize_event_best_effort(ready, "cudaEventSynchronize over-cap buffer failed");
+    torchlean_cuda_destroy_event_best_effort(ready, "cudaEventDestroy over-cap buffer failed");
+    torchlean_cuda_free_best_effort(data, "cudaFree over-cap buffer failed");
+  }
 }
 
 static void torchlean_cuda_flush_cached_blocks(void) {
@@ -161,6 +210,7 @@ static void torchlean_cuda_flush_cached_blocks(void) {
   g_torchlean_cuda_cache = nullptr;
   g_torchlean_cuda_cache_count = 0;
   g_torchlean_cuda_cache_cap = 0;
+  g_torchlean_cuda_cache_bytes = 0;
   torchlean_cuda_unlock(&g_torchlean_cuda_cache_mutex, "pthread_mutex_unlock buffer flush failed");
 
   for (size_t i = 0; i < count; ++i) {
@@ -774,6 +824,14 @@ extern "C" LEAN_EXPORT uint64_t torchlean_cuda_allocator_device_total_bytes(uint
   size_t totalBytes = 0;
   cudaError_t err = cudaMemGetInfo(&freeBytes, &totalBytes);
   return err == cudaSuccess ? (uint64_t)totalBytes : 0u;
+}
+
+extern "C" LEAN_EXPORT uint64_t torchlean_cuda_allocator_cache_bytes(uint32_t u) {
+  (void)u;
+  torchlean_cuda_lock(&g_torchlean_cuda_cache_mutex, "pthread_mutex_lock cache-bytes query failed");
+  uint64_t bytes = (uint64_t)g_torchlean_cuda_cache_bytes;
+  torchlean_cuda_unlock(&g_torchlean_cuda_cache_mutex, "pthread_mutex_unlock cache-bytes query failed");
+  return bytes;
 }
 
 extern "C" LEAN_EXPORT uint32_t torchlean_cuda_buffer_size(b_lean_obj_arg BObj) {

--- a/csrc/cuda/tensor/torchlean_cuda_tensor_stub.c
+++ b/csrc/cuda/tensor/torchlean_cuda_tensor_stub.c
@@ -210,6 +210,13 @@ LEAN_EXPORT uint64_t torchlean_cuda_allocator_device_total_bytes(uint32_t u) {
   return 0u;
 }
 
+// The CPU stub frees dropped buffers immediately and keeps no reuse cache, so there is nothing to
+// cap and no cached bytes to report.
+LEAN_EXPORT uint64_t torchlean_cuda_allocator_cache_bytes(uint32_t u) {
+  (void)u;
+  return 0u;
+}
+
 LEAN_EXPORT uint32_t torchlean_cuda_buffer_size(b_lean_obj_arg BObj) {
   torchlean_cuda_buffer* b = torchlean_cuda_buffer_unbox(BObj);
   if (b->size > 0xFFFFFFFFULL) {


### PR DESCRIPTION
## Summary

Rebased onto the latest `main` (the Lean 4.32 refactor), as a single commit. Adds an opt-in byte cap
on the CUDA buffer **reuse cache** (the exact-size device-block free list behind `take_cached_block` /
`return_cached_block`).

The cache grows without bound: a dropped buffer is returned to it, and it is only emptied on a
`cudaMalloc`-failure flush or at process exit. A loop over many distinct buffer sizes therefore
accretes device memory that `liveBytes` does not even see — a returned block is accounted as *freed*
before it is cached.

`TORCHLEAN_CUDA_CACHE_CAP_BYTES` (0 = unbounded, the prior behaviour exactly) bounds it: a returned
block that would grow the cache past the cap is freed immediately — after waiting on its completion
event, exactly as the flush path does, so an in-flight kernel never reads freed memory — instead of
being cached.

## What's in it

- A running `cache_bytes` total under the cache mutex backs the cap decision.
- New telemetry field `AllocatorStats.cacheBytes` (extern `torchlean_cuda_allocator_cache_bytes`; the
  CPU stub returns `0`); `AllocatorStats.format` gains ` cache=<MiB>`.

## Review changes addressed

- **Self-contained strict decimal parser (no `strtoull`)** — the cap is parsed by a small
  hand-rolled loop that accepts exactly a non-empty digit string fitting in `size_t`; malformed or
  overflowing values are rejected with a warning and leave the cache unbounded, instead of being
  silently misread (`strtoull` would take `1MiB` as a 1-byte cap and saturate overflow to
  `ULLONG_MAX`). This also removes the only `strto*` reference in the CUDA objects, so the branch
  links against the Lean toolchain's glibc with no compatibility layer — no dependency on #18.
- **Thread-safe one-time env init** — the cap is read from the environment under `pthread_once`
  (`torchlean_cuda_cache_byte_cap_init`), so concurrent first callers cannot race on the parse and the
  value is published before any caller observes it. (The prior function-local `static` assigned after
  its declaration was a data race and depended on `-fthreadsafe-statics`.)
- **Overflow-safe cap comparison** — `cache_bytes + incoming > cap` is reformulated as
  `incoming > cap || cache_bytes > cap - incoming`, so the sum is never formed and cannot wrap
  `size_t` (and `cap - incoming` is only evaluated when `incoming <= cap`).
- **Control subprocess pinned to `0`** — the fork helper always sets `TORCHLEAN_CUDA_CACHE_CAP_BYTES`
  in the child's environment (capped = `1048576`, control = `0`), so neither child inherits a stray
  cap from the parent and the control run genuinely exercises unbounded growth.

## Test

`runCacheCapTest` (in `nn_tests_suite`, runs on both the CUDA build and the CPU stub). The cap is read
once natively, so the test forks the suite binary per configuration:

- **capped** — a 1 MiB cap bounds an 8 MiB return workload to a 1 MiB cache;
- **control** — with the cap explicitly `0` the same workload caches the full 8 MiB;
- **malformed** — `1MiB` is rejected and the cache stays unbounded (a prefix-parsing reader would
  cache nothing under a 1-byte cap);
- **overflow** — a value past the native word is rejected rather than truncated or saturated.

On CUDA it also checks the cap is the *binding* constraint (the cache fills to within one block of it).
On the stub `cacheBytes` stays 0, so the cap bound holds trivially.

## Verification

CPU-stub `lake build && lake exe nn_tests_suite`: green, all four fork cases pass. Full CUDA build +
suite re-run on an RTX A4500 (CUDA 13.0), built deliberately **without** any glibc compatibility
object: links clean and all curated tests pass, with all four fork cases confirming the cap and the
rejection semantics on the real allocator.

