### PR TITLE
feat(floats): Sterbenz exact subtraction for the FLT / FP32 formats

### DIFF
--- a/NN/Floats/FP32.lean
+++ b/NN/Floats/FP32.lean
@@ -9,6 +9,7 @@ module
 public import NN.Floats.FP32.Error
 public import NN.Floats.FP32.Notation
 public import NN.Floats.FP32.RuntimeApprox
+public import NN.Floats.FP32.Sterbenz
 import Mathlib.Algebra.Order.Algebra
 
 /-!

--- a/NN/Floats/FP32/Sterbenz.lean
+++ b/NN/Floats/FP32/Sterbenz.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 TorchLean
+Released under MIT license as described in the file LICENSE.
+Authors: TorchLean Team
+-/
+
+module
+
+public import NN.Floats.FP32.Notation
+public import NN.Floats.NeuralFloat.Analysis.SterbenzFLT
+
+/-!
+# `FP32` Sterbenz: exact subtraction of near-equal binary32 values
+
+Sterbenz's lemma at the binary32 configuration `fexp32 = FLTExp (-149) 24`.  If two representable
+binary32 values are within a factor of two of each other, their difference is *exactly*
+representable, so the binary32 subtraction incurs **no rounding error at all**.
+
+Two forms are provided:
+
+- `round32_sub_exact_of_sterbenz` — the spec-level statement about the rounding operator `round₃₂`:
+  under the Sterbenz hypotheses, `round₃₂ (u - v) = u - v`.  This is Sterbenz's lemma as a theorem
+  about `round₃₂`.
+- `FP32.sub_exact_of_sterbenz` — the corollary phrased on the `FP32` scalar type:
+  `(a - b).val = a.val - b.val` for representable `a`, `b`.
+
+The proof composes the `FLT` Sterbenz lemma (`neural_generic_format_FLT_sterbenz`, which the
+binary32 exponent function `fexp32` is an instance of) with the fact that rounding is the identity on
+already-representable reals (`neural_round_preserves_generic`).
+-/
+
+@[expose] public section
+
+namespace TorchLean.Floats
+
+/--
+Sterbenz's lemma for binary32, stated on the rounding operator: if `u` and `v` are representable
+binary32 values with `0 < u`, `0 < v`, `u ≤ 2v`, and `v ≤ 2u`, then rounding their exact difference
+is a no-op — `u - v` is already on the binary32 grid.
+-/
+theorem round32_sub_exact_of_sterbenz {u v : ℝ}
+    (hu : neuralGenericFormat binaryRadix fexp32 u)
+    (hv : neuralGenericFormat binaryRadix fexp32 v)
+    (hupos : 0 < u) (hvpos : 0 < v) (huv : u ≤ 2 * v) (hvu : v ≤ 2 * u) :
+    round₃₂ (u - v) = u - v := by
+  -- `fexp32` is `FLTExp (-149) 24`; the `FLT` Sterbenz lemma gives a representable difference.
+  have hfmt : neuralGenericFormat binaryRadix fexp32 (u - v) :=
+    neural_generic_format_FLT_sterbenz (-149) 24 (by decide) hupos hvpos huv hvu hu hv
+  -- Rounding is the identity on representable reals; `round₃₂` reduces to `neuralRound`.
+  exact neural_round_preserves_generic (β := binaryRadix) (fexp := fexp32) rnd32 (u - v) hfmt
+
+namespace FP32
+
+/--
+Sterbenz's lemma on the `FP32` scalar type: for representable `a`, `b` within a factor of two,
+subtraction is exact, `(a - b).val = a.val - b.val`.  The result carries the operational meaning
+that a near-equal binary32 subtraction is lossless.
+-/
+theorem sub_exact_of_sterbenz {a b : FP32}
+    (ha : a.IsRepresentable) (hb : b.IsRepresentable)
+    (hapos : 0 < a.val) (hbpos : 0 < b.val)
+    (hab : a.val ≤ 2 * b.val) (hba : b.val ≤ 2 * a.val) :
+    (a - b).val = a.val - b.val := by
+  -- `(a - b).val` is by definition `round₃₂ (a.val - b.val)`.
+  have hround : (a - b).val = round₃₂ (a.val - b.val) := rfl
+  rw [hround]
+  exact round32_sub_exact_of_sterbenz ha hb hapos hbpos hab hba
+
+end FP32
+
+end TorchLean.Floats

--- a/NN/Floats/NeuralFloat/Analysis.lean
+++ b/NN/Floats/NeuralFloat/Analysis.lean
@@ -9,6 +9,7 @@ module
 public import NN.Floats.NeuralFloat.Analysis.Neighbors
 public import NN.Floats.NeuralFloat.Analysis.StandardUlp
 public import NN.Floats.NeuralFloat.Analysis.Sterbenz
+public import NN.Floats.NeuralFloat.Analysis.SterbenzFLT
 public import NN.Floats.NeuralFloat.Analysis.Ulp
 
 /-!

--- a/NN/Floats/NeuralFloat/Analysis/SterbenzFLT.lean
+++ b/NN/Floats/NeuralFloat/Analysis/SterbenzFLT.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 TorchLean
+Released under MIT license as described in the file LICENSE.
+Authors: TorchLean Team
+-/
+
+module
+
+public import NN.Floats.NeuralFloat.Analysis.Sterbenz
+public import NN.Floats.NeuralFloat.Error.Addition
+public import NN.Floats.NeuralFloat.Error.Multiplication
+
+/-!
+# Sterbenz's lemma for the gradual-underflow format `FLT`
+
+`Analysis/Sterbenz.lean` proves Sterbenz's lemma for the unbounded-exponent family `FLX`.  Real
+IEEE-style formats (in particular binary32, `FLTExp (-149) 24`) are `FLT`: a fixed underflow floor
+`emin` with `max (e - prec) emin`.  This file lifts Sterbenz's lemma from `FLX` to `FLT`, so that the
+exact-subtraction guarantee applies to the format that `FP32` actually uses.
+
+The proof splits on the magnitude of the result relative to the underflow boundary
+`β^(prec + emin)`:
+
+- **Subnormal regime** (`|x - y| ≤ β^(prec + emin)`): every `FLT` value lies on its minimum-exponent
+  `FIX` grid (`neural_generic_format_FLT_to_FIX`), that grid is closed under subtraction
+  (`neural_generic_format_FIX_sub`), and a small `FIX` value is `FLT`
+  (`neural_generic_format_FIX_to_FLT_of_abs_le`).  No ratio hypothesis is needed here — the fixed
+  grid subtracts exactly.
+
+- **Normal regime** (`β^(prec + emin) < |x - y|`): both operands are `FLX`
+  (`neural_generic_format_FLT_to_FLX`), the `FLX` Sterbenz lemma gives an exact `FLX` difference,
+  and a normal-range `FLX` value is `FLT` (`neural_generic_format_FLX_to_FLT_of_normal`, proved
+  below).  This is where the ratio hypotheses `x ≤ 2y`, `y ≤ 2x` are used.
+-/
+
+@[expose] public section
+
+namespace TorchLean.Floats
+
+variable {β : NeuralRadix}
+
+/--
+A normal-range `FLX` value is `FLT`.
+
+`FLX` and `FLT` agree on every value whose magnitude sits in the normal range.  Concretely: an `FLX`
+value with `β^(prec + emin) ≤ |x|` has an effective exponent at least `emin`, so it also meets the
+`FLT` underflow floor.  This is the converse, restricted to the normal range, of the unconditional
+inclusion `neural_generic_format_FLT_to_FLX`.
+-/
+theorem neural_generic_format_FLX_to_FLT_of_normal (emin prec : ℤ) (hprec : 0 < prec)
+    {x : ℝ} (hxFLX : @neuralGenericFormat β (FLXExp prec) (flxValidExp prec hprec) x)
+    (hnorm : neuralBpow β (prec + emin) ≤ abs x) :
+    @neuralGenericFormat β (FLTExp emin prec) (fltValidExp emin prec hprec) x := by
+  letI : NeuralValidExp (FLXExp prec) := flxValidExp prec hprec
+  letI : NeuralValidExp (FLTExp emin prec) := fltValidExp emin prec hprec
+  obtain ⟨f, hxf, hmant⟩ := (generic_format_FLX_iff (β := β) prec hprec x).mp hxFLX
+  -- It suffices to promote the `FLX` witness to an `FLT` witness by establishing the floor.
+  refine (generic_format_FLT_iff (β := β) emin prec hprec x).mpr ⟨f, hxf, hmant, ?_⟩
+  -- Turn the mantissa bound into a real bound `|f.mantissa| < β^prec`.
+  have hmabs : abs (f.mantissa : ℝ) = (f.mantissa.natAbs : ℝ) := by
+    cases f.mantissa with
+    | ofNat n => simp
+    | negSucc n =>
+        rw [Int.cast_negSucc, abs_of_neg]
+        · norm_num
+        · exact neg_neg_of_pos (by positivity : (0 : ℝ) < (n + 1 : ℕ))
+  have hmantR : abs (f.mantissa : ℝ) < neuralBpow β prec := by
+    rw [hmabs, neuralBpow_eq_natPow (β := β) prec hprec.le]
+    exact_mod_cast hmant
+  -- Hence `|x| < β^(f.exponent + prec)`.
+  have habsx : abs x < neuralBpow β (f.exponent + prec) := by
+    rw [hxf, neuralToReal, abs_mul, abs_of_pos (neuralBpow.pos β f.exponent)]
+    calc
+      abs (f.mantissa : ℝ) * neuralBpow β f.exponent <
+          neuralBpow β prec * neuralBpow β f.exponent :=
+        mul_lt_mul_of_pos_right hmantR (neuralBpow.pos β f.exponent)
+      _ = neuralBpow β (f.exponent + prec) := by
+        rw [← neuralBpow.add_exp]; congr 1; linarith
+  -- Combined with the normal-range lower bound, the exponent clears `emin`.
+  have hlt : neuralBpow β (prec + emin) < neuralBpow β (f.exponent + prec) :=
+    lt_of_le_of_lt hnorm habsx
+  have hexp : prec + emin < f.exponent + prec := (neuralBpow_lt_neuralBpow_iff β _ _).mp hlt
+  linarith
+
+/--
+Sterbenz's lemma for `FLT`, directed form: if `0 < y ≤ x ≤ 2y` and both are `FLT`-representable,
+their exact difference is `FLT`-representable.
+-/
+theorem neural_generic_format_FLT_sub_of_le_two_mul (emin prec : ℤ) (hprec : 0 < prec)
+    {x y : ℝ} (hy : 0 < y) (hyx : y ≤ x) (hx2y : x ≤ 2 * y)
+    (hxFmt : @neuralGenericFormat β (FLTExp emin prec) (fltValidExp emin prec hprec) x)
+    (hyFmt : @neuralGenericFormat β (FLTExp emin prec) (fltValidExp emin prec hprec) y) :
+    @neuralGenericFormat β (FLTExp emin prec) (fltValidExp emin prec hprec) (x - y) := by
+  letI : NeuralValidExp (FLTExp emin prec) := fltValidExp emin prec hprec
+  letI : NeuralValidExp (FLXExp prec) := flxValidExp prec hprec
+  by_cases hxy : x = y
+  · rw [hxy, sub_self]; exact neural_generic_format_zero
+  have hx : 0 < x := hy.trans_le hyx
+  have hdpos : 0 < x - y := sub_pos.mpr (lt_of_le_of_ne hyx (Ne.symm hxy))
+  by_cases hsmall : abs (x - y) ≤ neuralBpow β (prec + emin)
+  · -- Subnormal regime: the fixed underflow grid subtracts exactly.
+    have hxFix := neural_generic_format_FLT_to_FIX (β := β) emin prec hprec hxFmt
+    have hyFix := neural_generic_format_FLT_to_FIX (β := β) emin prec hprec hyFmt
+    have hdFix := neural_generic_format_FIX_sub (β := β) emin hxFix hyFix
+    exact neural_generic_format_FIX_to_FLT_of_abs_le (β := β) emin prec hprec hdFix hsmall
+  · -- Normal regime: transport through the unbounded `FLX` family.
+    rw [not_le] at hsmall
+    have hxFLX := neural_generic_format_FLT_to_FLX (β := β) emin prec hprec hxFmt
+    have hyFLX := neural_generic_format_FLT_to_FLX (β := β) emin prec hprec hyFmt
+    have hdFLX := neural_generic_format_FLX_sub_of_le_two_mul (β := β) prec hprec
+      hy hyx hx2y hxFLX hyFLX
+    exact neural_generic_format_FLX_to_FLT_of_normal (β := β) emin prec hprec
+      hdFLX (le_of_lt hsmall)
+
+/--
+Symmetric Sterbenz lemma for `FLT`.  If two positive `FLT`-representable values are within a factor
+of two, their exact difference is `FLT`-representable, whichever operand is larger.
+
+This is the format-faithful analogue of `neural_generic_format_FLX_sterbenz`: it holds for the
+gradual-underflow format `FLTExp emin prec` that real binary formats (e.g. `fexp32`) use, across the
+whole exponent range including the subnormal boundary.
+-/
+theorem neural_generic_format_FLT_sterbenz (emin prec : ℤ) (hprec : 0 < prec)
+    {x y : ℝ} (hx : 0 < x) (hy : 0 < y) (hx2y : x ≤ 2 * y) (hy2x : y ≤ 2 * x)
+    (hxFmt : @neuralGenericFormat β (FLTExp emin prec) (fltValidExp emin prec hprec) x)
+    (hyFmt : @neuralGenericFormat β (FLTExp emin prec) (fltValidExp emin prec hprec) y) :
+    @neuralGenericFormat β (FLTExp emin prec) (fltValidExp emin prec hprec) (x - y) := by
+  letI : NeuralValidExp (FLTExp emin prec) := fltValidExp emin prec hprec
+  rcases le_total y x with hyx | hxy
+  · exact neural_generic_format_FLT_sub_of_le_two_mul emin prec hprec hy hyx hx2y hxFmt hyFmt
+  · have hdiff := neural_generic_format_FLT_sub_of_le_two_mul emin prec hprec hx hxy hy2x hyFmt hxFmt
+    have hneg := neural_generic_format_neg (β := β) (fexp := FLTExp emin prec) (y - x) hdiff
+    simpa only [neg_sub] using hneg
+
+end TorchLean.Floats


### PR DESCRIPTION
Analysis/Sterbenz.lean proves Sterbenz's lemma only for the unbounded-exponent family FLX. Real IEEE-style formats are FLT (a fixed underflow floor emin with max (e - prec) emin), so the existing lemma does not directly cover the exact subtraction guarantee for, e.g., binary32 (FLTExp (-149) 24).

Add Analysis/SterbenzFLT.lean:
  - neural_generic_format_FLX_to_FLT_of_normal: a normal-range FLX value (beta^(prec+emin) <= |x|) is FLT; the normal-range converse of the existing unconditional inclusion neural_generic_format_FLT_to_FLX.
  - neural_generic_format_FLT_sub_of_le_two_mul / neural_generic_format_FLT_sterbenz: Sterbenz's lemma for FLT. The proof splits on the underflow boundary:
      * |x-y| <= beta^(prec+emin): the fixed emin grid subtracts exactly (FLT_to_FIX -> FIX_sub -> FIX_to_FLT_of_abs_le), no ratio hypothesis;
      * beta^(prec+emin) < |x-y|: transport through FLX (FLT_to_FLX -> FLX_sterbenz -> FLX_to_FLT_of_normal), where the factor-of-two ratio hypotheses are used.

Add FP32/Sterbenz.lean:
  - round32_sub_exact_of_sterbenz: Sterbenz as a theorem about the rounding operator, round32 (u - v) = u - v for representable u, v within a factor of two.
  - FP32.sub_exact_of_sterbenz: the corollary on the FP32 scalar type, (a - b).val = a.val - b.val; a near-equal binary32 subtraction is lossless. Composes neural_generic_format_FLT_sterbenz (fexp32 is FLTExp (-149) 24) with neural_round_preserves_generic (rounding is the identity on representable reals).

Both new files are wired into the Analysis and FP32 umbrella imports. All new theorems depend only on [propext, Classical.choice, Quot.sound].