### PR TITLE
feat(cuda): bundle + auto-link the glibc≥2.38 isoc23 link shim

### DIFF
--- a/csrc/cuda/common/torchlean_isoc23_shim.c
+++ b/csrc/cuda/common/torchlean_isoc23_shim.c
@@ -1,0 +1,40 @@
+/*
+ * glibc >= 2.38 isoc23 link shim for the CUDA build.
+ *
+ * On glibc >= 2.38 the `strto*` family is redirected to `__isoc23_strto*` under
+ * `_GNU_SOURCE` (which nvcc's host pass forces). nvcc-compiled host objects then
+ * reference `__isoc23_strtoull`/etc. When the final executable is linked against an
+ * *older* glibc than the one nvcc compiled with -- which is the case whenever the Lean
+ * toolchain bundles a pre-2.38 glibc -- those symbols are undefined and the CUDA link
+ * fails (`undefined reference to __isoc23_strtoull`).
+ *
+ * This object *defines* the referenced names as thin wrappers over the plain, still
+ * resolvable `strto*` (declared directly below so this file itself does not go through
+ * the C23 redirect). The definitions are `weak`, so a link-time glibc that already
+ * exports the real `__isoc23_strto*` wins and this shim is ignored; when it does not,
+ * these satisfy the references. It is compiled and linked only into the CUDA build, and
+ * is inert on any host whose objects never reference these names (older glibc, non-CUDA).
+ *
+ * A `-Wl,--defsym=__isoc23_strtoull=strtoull` alias does NOT work here: lld resolves the
+ * defsym target among *defined* symbols, but with the C23 redirect nothing references the
+ * plain `strtoull`, so lld reports `symbol not found: strtoull`. A real definition (this
+ * file) is required.
+ */
+
+extern unsigned long long strtoull(const char *, char **, int);
+extern long long          strtoll (const char *, char **, int);
+extern unsigned long      strtoul (const char *, char **, int);
+extern long               strtol  (const char *, char **, int);
+
+__attribute__((weak)) unsigned long long __isoc23_strtoull(const char *p, char **e, int b) {
+  return strtoull(p, e, b);
+}
+__attribute__((weak)) long long __isoc23_strtoll(const char *p, char **e, int b) {
+  return strtoll(p, e, b);
+}
+__attribute__((weak)) unsigned long __isoc23_strtoul(const char *p, char **e, int b) {
+  return strtoul(p, e, b);
+}
+__attribute__((weak)) long __isoc23_strtol(const char *p, char **e, int b) {
+  return strtol(p, e, b);
+}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -189,10 +189,29 @@ target torchlean_libtorch_sdpa_stub pkg : FilePath :=
   else
     pure (Job.pure (pkg.buildDir / "torchlean_libtorch_sdpa_stub_skipped"))
 
+/-- Compile the glibc ≥ 2.38 isoc23 link shim (`csrc/cuda/common/torchlean_isoc23_shim.c`).
+
+nvcc's host pass under `_GNU_SOURCE` references `__isoc23_strto*`, which an older link-time
+glibc (as bundled by the Lean toolchain) does not export, breaking the CUDA link. This tiny
+object *defines* those names as weak wrappers over the plain `strto*`; see the source header. -/
+private def buildIsoc23Shim (pkg : Package) := do
+  let srcJob ← inputFile (pkg.dir / "csrc/cuda/common/torchlean_isoc23_shim.c") false
+  let oFile := pkg.buildDir / "torchlean_isoc23_shim.o"
+  buildO oFile srcJob #["-O2", "-fPIC"] #[] "cc"
+
+/-- The isoc23 link shim as a linkable object; built and linked only for the CUDA build, so
+non-CUDA builds are byte-for-byte unchanged. Weak symbols make it inert where unneeded. -/
+target torchlean_isoc23_shim pkg : FilePath :=
+  if cudaEnabled then
+    buildIsoc23Shim pkg
+  else
+    pure (Job.pure (pkg.buildDir / "torchlean_isoc23_shim_skipped"))
+
 @[default_target]
 lean_lib NN where
   moreLinkObjs :=
-    if cudaEnabled && libtorchEnabled then #[torchlean_libtorch_sdpa_so]
+    if cudaEnabled && libtorchEnabled then #[torchlean_libtorch_sdpa_so, torchlean_isoc23_shim]
+    else if cudaEnabled then #[torchlean_libtorch_sdpa_stub, torchlean_isoc23_shim]
     else #[torchlean_libtorch_sdpa_stub]
   -- The reusable library follows its canonical umbrella. Examples, tests, CI-only modules,
   -- documentation, and executable roots have separate targets below.


### PR DESCRIPTION
On glibc ≥ 2.38 (Ubuntu 24.04, Fedora ≥ 38, Debian 13, recent EL9, …) the `strto*`
family is redirected to `__isoc23_strto*` under `_GNU_SOURCE`, which nvcc's host pass
forces. nvcc-compiled host objects then reference `__isoc23_strtoull`/etc.; when the
final executable is linked against an older glibc than nvcc compiled with — the case
whenever the Lean toolchain bundles a pre-2.38 glibc — those symbols are undefined and
the CUDA link fails:

```
ld.lld: error: undefined symbol: __isoc23_strtoull
```

This bundles a tiny object (`csrc/cuda/common/torchlean_isoc23_shim.c`) that *defines*
the four referenced names as **weak** wrappers over the plain `strto*` (declared
directly, so the file itself skips the C23 redirect), and compiles + links it
automatically into the CUDA build via a Lake target in the `NN` library's `moreLinkObjs`
— only when `-K cuda=true`. No `-K` flag or user-supplied object path is needed.

The symbols are `weak`, so a link-time glibc that already exports the real
`__isoc23_strto*` takes precedence, and the shim is inert on hosts whose objects never
reference these names (older glibc; and non-CUDA builds, which stay byte-for-byte
unchanged since the object is only linked under `-K cuda=true`). A
`-Wl,--defsym=__isoc23_strtoull=strtoull` alias does **not** work: lld resolves the
defsym target among *defined* symbols, but the C23 redirect leaves nothing referencing
the plain `strtoull`, so lld reports `symbol not found: strtoull` — a real definition is
required.

Verified: a `-K cuda=true` build (no extra flags) links cleanly and runs the full CUDA
test suite on Ubuntu 24.04 (glibc 2.39); without the shim the same build fails at link
with the undefined `__isoc23_strtoull`. This also unblocks #10 (its byte-cap parses
`TORCHLEAN_CUDA_CACHE_CAP_BYTES` with `strtoull`, hitting the same reference) on
glibc ≥ 2.38.
