### PR TITLE
Make CUDA GPT-2 training defaults fast with LibTorch SDPA.

### DIFF
--- a/NN/API/Models/Gpt2.lean
+++ b/NN/API/Models/Gpt2.lean
@@ -136,7 +136,8 @@ def causalTransformerTokenScalarModuleDefWithMode
     TorchLean.Module.ScalarModuleDef
       ((.dim cfg.vocab (.dim cfg.dModel .scalar)) :: paramShapes body) [] :=
   { initParams :=
-      .cons (Spec.zeros Float (.dim cfg.vocab (.dim cfg.dModel .scalar))) (initParams body)
+      _root_.Runtime.Autograd.TorchLean.Module.RuntimeInit.zeroFloatTList
+        (ss := (.dim cfg.vocab (.dim cfg.dModel .scalar)) :: paramShapes body)
     runtimeInit :=
       match _root_.Runtime.Autograd.TorchLean.NN.Seq.runtimeInit? body with
       | some bodyPlan => some (.cons .zeros bodyPlan)
@@ -204,20 +205,32 @@ ids: the eager backend rejects negative or fractional values before indexing the
 This gives the PyTorch-shaped training path, `nn.Embedding` followed by row-wise cross entropy,
 without rebuilding the module at every text window. Optimizer state therefore stays attached to the
 same persistent parameter session.
+
+Storage-first defaults: host `initParams` are cheap zero placeholders. When the body supplies a
+`runtimeInit` plan, `instantiateFloat` allocates/fills embedding + body weights in backend storage
+(CUDA when `opts.usesCuda`) instead of materializing `Seq.initParams` on the host.
 -/
 def causalTransformerTokenIdLmScalarModuleDefWithMode
     (mode : _root_.Runtime.Autograd.TorchLean.NN.Mode)
     (cfg : CausalOneHotConfig)
     (body : nn.Sequential (causalEmbeddingShape cfg) (causalOneHotShape cfg))
-    (initParams : _root_.Runtime.Autograd.Torch.TList Float
-      ((.dim cfg.vocab (.dim cfg.dModel .scalar)) :: paramShapes body))
-    (reduction : TorchLean.Loss.Reduction := .mean) :
+    (reduction : TorchLean.Loss.Reduction := .mean)
+    (embedInitSeed : Nat := 0) :
     TorchLean.Module.ScalarModuleDef
       ((.dim cfg.vocab (.dim cfg.dModel .scalar)) :: paramShapes body)
       [causalTokenIdLmInputShape cfg, causalTokenIdLmInputShape cfg] :=
-  { initParams := initParams
-    initRequiresGrad :=
-      List.replicate (((.dim cfg.vocab (.dim cfg.dModel .scalar)) :: paramShapes body).length) true
+  let ss := (.dim cfg.vocab (.dim cfg.dModel .scalar)) :: paramShapes body
+  { initParams :=
+      _root_.Runtime.Autograd.TorchLean.Module.RuntimeInit.zeroFloatTList (ss := ss)
+    runtimeInit :=
+      match _root_.Runtime.Autograd.TorchLean.NN.Seq.runtimeInit? body with
+      | some bodyPlan =>
+          some
+            (.cons
+              (.uniform (-0.02) 0.02 embedInitSeed)
+              bodyPlan)
+      | none => none
+    initRequiresGrad := List.replicate ss.length true
     loss := fun {α} => by
       intro _ _
       exact fun {m} _ _ =>
@@ -262,17 +275,17 @@ def causalTransformerTokenIdLmScalarModuleDefWithMode
 Training-mode wrapper for float-encoded token-id causal language modeling.
 
 Use this when the body consumes embeddings and emits logits, while the dataset supplies changing
-integer token-id windows.
+integer token-id windows. Prefer `instantiateFloat` so the attached `runtimeInit` plan runs.
 -/
 def causalTransformerTokenIdLmScalarModuleDef (cfg : CausalOneHotConfig)
     (body : nn.Sequential (causalEmbeddingShape cfg) (causalOneHotShape cfg))
-    (initParams : _root_.Runtime.Autograd.Torch.TList Float
-      ((.dim cfg.vocab (.dim cfg.dModel .scalar)) :: paramShapes body))
-    (reduction : TorchLean.Loss.Reduction := .mean) :
+    (reduction : TorchLean.Loss.Reduction := .mean)
+    (embedInitSeed : Nat := 0) :
     TorchLean.Module.ScalarModuleDef
       ((.dim cfg.vocab (.dim cfg.dModel .scalar)) :: paramShapes body)
       [causalTokenIdLmInputShape cfg, causalTokenIdLmInputShape cfg] :=
-  causalTransformerTokenIdLmScalarModuleDefWithMode .train cfg body initParams (reduction := reduction)
+  causalTransformerTokenIdLmScalarModuleDefWithMode .train cfg body
+    (reduction := reduction) (embedInitSeed := embedInitSeed)
 
 end models
 end nn

--- a/NN/Backend/Attention.lean
+++ b/NN/Backend/Attention.lean
@@ -84,7 +84,7 @@ def nativeFlashAttention : KernelCapsule :=
         (.vjpRefinement scaledDotProductOp "Spec.flashAttentionBackward" .backendVJP)
         "CUDA VJP kernels return dQ, dK, and dV for the fused operator."
         "NN.Tests.Runtime.Cuda.Attention"
-    notes := "This is the default fused CUDA capsule until a planner explicitly selects LibTorch." }
+    notes := "Default fused CUDA capsule when LibTorch is not enabled." }
 
 /-- LibTorch SDPA forward provider while TorchLean keeps the graph/tape boundary. -/
 def libTorchSDPAForward : KernelCapsule :=
@@ -96,7 +96,7 @@ def libTorchSDPAForward : KernelCapsule :=
     trustLevel := .trustedExternal
     supportsForward := true
     vjpMode := .torchLeanTape
-    runtimeSupport := .testOnly
+    runtimeSupport := .eager
     shapeContract :=
       ContractDescriptor.guarded (.shapeSafety scaledDotProductOp)
         "Q/K/V are checked as (heads, n, headDim); optional mask as (heads, n, n)."
@@ -121,7 +121,7 @@ def libTorchSDPAForward : KernelCapsule :=
         "TorchLean records the node and keeps the backward boundary inside TorchLean."
         "backend profile requires vjpMode=torchLeanTape"
     notes :=
-      "This is the preferred scaling direction: LibTorch provides the forward value, while TorchLean keeps the graph/backward contract. The runtime bridge is not wired into eager MHA yet." }
+      "LibTorch forward + TorchLean composed attention VJP on the CUDA tape." }
 
 /-- LibTorch SDPA provider where LibTorch also owns the local autograd VJP. -/
 def libTorchSDPAAutograd : KernelCapsule :=
@@ -133,7 +133,7 @@ def libTorchSDPAAutograd : KernelCapsule :=
     trustLevel := .trustedExternal
     supportsForward := true
     vjpMode := .externalAutograd
-    runtimeSupport := .testOnly
+    runtimeSupport := .eager
     shapeContract :=
       ContractDescriptor.guarded (.shapeSafety scaledDotProductOp)
         "Q/K/V and dOut are checked as (heads, n, headDim); optional mask as (heads, n, n)."
@@ -158,34 +158,56 @@ def libTorchSDPAAutograd : KernelCapsule :=
         "LibTorch autograd VJP for scaled_dot_product_attention."
         "LibTorch autograd for SDPA"
     notes :=
-      "This is the largest trust boundary: LibTorch owns both the forward value and local VJP. Use only when explicitly selecting external autograd." }
+      "Preferred training path when LibTorch is linked: PyTorch SDPA owns forward and local VJP." }
 
-/-- Candidate capsules in default CUDA planner order. -/
+/-- Candidate capsules in default CUDA planner order (no LibTorch). -/
 def cudaCandidates : List KernelCapsule :=
   [nativeFlashAttention, torchLeanComposed]
 
 /-- Candidate capsules when the optional LibTorch backend is enabled by policy/config. -/
 def cudaCandidatesWithLibTorch : List KernelCapsule :=
-  [libTorchSDPAForward, libTorchSDPAAutograd, nativeFlashAttention, torchLeanComposed]
+  [libTorchSDPAAutograd, libTorchSDPAForward, nativeFlashAttention, torchLeanComposed]
+
+/-- Concrete CUDA attention implementation selected from a capsule. -/
+inductive CudaAttentionImpl where
+  /-- Native fused FlashAttention kernels. -/
+  | nativeFlash
+  /-- LibTorch SDPA forward + LibTorch autograd VJP. -/
+  | libTorchAutograd
+  /-- LibTorch SDPA forward + TorchLean composed VJP. -/
+  | libTorchForward
+  /-- Fully composed TorchLean `bmm -> softmax -> bmm` path. -/
+  | composed
+deriving DecidableEq, Repr
 
 /--
 Runtime implementation selector for CUDA attention.
-
-`true` means call the fused native CUDA attention kernels. `false` means use the composed
-TorchLean expression (`bmm -> softmax -> bmm`) on the CUDA tape. External providers such as
-LibTorch intentionally fail here until their runtime bridge is wired through an explicit capsule.
 -/
-def cudaUsesNativeFlash (c : KernelCapsule) : Except String Bool :=
+def cudaAttentionImpl (c : KernelCapsule) : Except String CudaAttentionImpl :=
   if c.op != scaledDotProductOp then
     .error s!"backend capsule {c.name} does not implement {scaledDotProductOp.name}"
   else
     match c.provider with
-    | .nativeCuda => .ok true
-    | .torchLean | .reference => .ok false
+    | .nativeCuda => .ok .nativeFlash
+    | .torchLean | .reference => .ok .composed
     | .libTorch =>
-        .error s!"LibTorch SDPA capsule `{c.name}` is registered, but eager multi-head attention is not wired to LibTorch execution yet"
+        match c.vjpMode with
+        | .externalAutograd => .ok .libTorchAutograd
+        | .torchLeanTape | .backendVJP | .none => .ok .libTorchForward
     | p =>
         .error s!"backend provider {reprStr p} is not wired for CUDA attention execution"
+
+/--
+Legacy selector: `true` means native fused flash kernels; `false` means composed TorchLean.
+
+LibTorch capsules are not represented by this Bool API — use `cudaAttentionImpl`.
+-/
+def cudaUsesNativeFlash (c : KernelCapsule) : Except String Bool := do
+  match ← cudaAttentionImpl c with
+  | .nativeFlash => pure true
+  | .composed => pure false
+  | .libTorchAutograd | .libTorchForward =>
+      .error s!"LibTorch SDPA capsule `{c.name}` requires `cudaAttentionImpl` (not Bool flash selector)"
 
 end Attention
 end Backend

--- a/NN/Runtime/Autograd/Engine/Cuda/Kernels.lean
+++ b/NN/Runtime/Autograd/Engine/Cuda/Kernels.lean
@@ -266,6 +266,17 @@ opaque libTorchSDPABwd
     (Q K V mask dOut : @& Buffer) (hasMask batch n d : UInt32) (scale : Float) :
     IO (Buffer × Buffer × Buffer)
 
+/-- Pure LibTorch SDPA forward for the CUDA tape (panics if LibTorch was not linked). -/
+@[extern "torchlean_libtorch_sdpa_fwd_buf"]
+opaque libTorchSDPAFwdBuf
+    (Q K V mask : @& Buffer) (hasMask batch n d : UInt32) (scale : Float) : Buffer
+
+/-- Pure LibTorch SDPA VJP for the CUDA tape (panics if LibTorch was not linked). -/
+@[extern "torchlean_libtorch_sdpa_bwd_buf"]
+opaque libTorchSDPABwdBuf
+    (Q K V mask dOut : @& Buffer) (hasMask batch n d : UInt32) (scale : Float) :
+    Buffer × Buffer × Buffer
+
 /--
 Row-major transpose of a 2D buffer.
 

--- a/NN/Runtime/Autograd/Engine/Cuda/Ops/Attention.lean
+++ b/NN/Runtime/Autograd/Engine/Cuda/Ops/Attention.lean
@@ -34,11 +34,8 @@ Forward structure matches `Spec.MultiHeadAttention.forward`:
 4. combine heads, then output projection `@ Wo`
 
 Masking:
-- If `useFlash = false`, the composed TorchLean fallback uses hard-mask semantics: blocked entries
-  contribute zero softmax numerator, matching the proof-facing attention spec.
-- If `useFlash = true`, the current CUDA build dispatches to the native fused runtime capsule.
-  Optional LibTorch SDPA capsules use the same hard boolean-mask semantics, but remain separate
-  external runtime and autograd boundaries.
+- Composed TorchLean uses hard-mask semantics: blocked entries contribute zero softmax numerator.
+- Native fused flash and LibTorch SDPA use the same hard boolean-mask semantics.
 - This incurs a host-to-device copy for the mask (since the mask is a host `Tensor Bool`).
 -/
 
@@ -48,7 +45,7 @@ def multiHeadAttention
   (mask : Option (Tensor Bool (.dim n (.dim n .scalar))) := none)
   (attentionCapsule : NN.Backend.KernelCapsule := NN.Backend.Attention.nativeFlashAttention) :
   Result (Tape × Nat) := do
-  let useFlash ← NN.Backend.Attention.cudaUsesNativeFlash attentionCapsule
+  let attnImpl ← NN.Backend.Attention.cudaAttentionImpl attentionCapsule
   have _ := h1
   let one32 : UInt32 := 1
   let depth0 : UInt32 := 0
@@ -88,23 +85,25 @@ def multiHeadAttention
         let axisMap : Array Nat := #[0, 1, 2]
         let maskB := Buffer.broadcastTo mF inDims outDims axisMap
         (Buffer.releaseThen mF maskB, 1)
-  -- Fused native attention over split heads. This replaces the composed
-  -- `scores -> mask -> softmax -> bmm` path while keeping the same spec contract.
   let (outHeads, attentionWorkspace) ←
-    if useFlash then
-      let outHeads := Buffer.flashAttentionFwd Qh Kh Vh maskB hasMask h32 n32 head32 scale
-      pure (outHeads, ([] : List Buffer))
-    else
-      let KhT := Buffer.swapAdjacentAtDepth Kh dimsHead depth1
-      let scores := Buffer.bmm Qh KhT h32 n32 head32 n32
-      let scaled0 := Buffer.scale scores scale
-      let rowsFold32 ← u32 (numHeads * n)
-      let attnOwned :=
-        match mask with
-        | none => rowSoftmaxForward scaled0 rowsFold32 n32
-        | some _ => rowHardMaskedSoftmaxForward scaled0 maskB rowsFold32 n32
-      let outHeads := Buffer.bmm attnOwned.value Vh h32 n32 n32 head32
-      pure (outHeads, [KhT, scores, scaled0, attnOwned.value] ++ attnOwned.workspace)
+    match attnImpl with
+    | .nativeFlash =>
+        let outHeads := Buffer.flashAttentionFwd Qh Kh Vh maskB hasMask h32 n32 head32 scale
+        pure (outHeads, ([] : List Buffer))
+    | .libTorchAutograd | .libTorchForward =>
+        let outHeads := Buffer.libTorchSDPAFwdBuf Qh Kh Vh maskB hasMask h32 n32 head32 scale
+        pure (outHeads, ([] : List Buffer))
+    | .composed =>
+        let KhT := Buffer.swapAdjacentAtDepth Kh dimsHead depth1
+        let scores := Buffer.bmm Qh KhT h32 n32 head32 n32
+        let scaled0 := Buffer.scale scores scale
+        let rowsFold32 ← u32 (numHeads * n)
+        let attnOwned :=
+          match mask with
+          | none => rowSoftmaxForward scaled0 rowsFold32 n32
+          | some _ => rowHardMaskedSoftmaxForward scaled0 maskB rowsFold32 n32
+        let outHeads := Buffer.bmm attnOwned.value Vh h32 n32 n32 head32
+        pure (outHeads, [KhT, scores, scaled0, attnOwned.value] ++ attnOwned.workspace)
   -- combine heads: swap to (n,numHeads,headDim), then reshape to (n,projDim)
   let swapped := Buffer.swapAdjacentAtDepth outHeads dimsHead depth0  -- (n,numHeads,headDim)
   let concat := swapped  -- view as (n,projDim)
@@ -130,13 +129,16 @@ def multiHeadAttention
         let dSwapped := dConcat -- view (n,numHeads,headDim)
         let dOutHeads := Buffer.swapAdjacentAtDepth dSwapped dimsView depth0 -- (numHeads,n,headDim)
         let (dQh, dKh, dVh) ←
-          if useFlash then
-            let (dQh, dKh, dVh) :=
-              Buffer.flashAttentionBwd Qh Kh Vh maskB dOutHeads hasMask h32 n32 head32 scale
-            -- The fused VJP reads `dOutHeads` but returns three fresh gradient buffers. Thread the
-            -- release through one returned buffer so every attention step retires this activation.
-            pure (Buffer.releaseThen dOutHeads dQh, dKh, dVh)
-          else
+          match attnImpl with
+          | .nativeFlash =>
+              let (dQh, dKh, dVh) :=
+                Buffer.flashAttentionBwd Qh Kh Vh maskB dOutHeads hasMask h32 n32 head32 scale
+              pure (Buffer.releaseThen dOutHeads dQh, dKh, dVh)
+          | .libTorchAutograd =>
+              let (dQh, dKh, dVh) :=
+                Buffer.libTorchSDPABwdBuf Qh Kh Vh maskB dOutHeads hasMask h32 n32 head32 scale
+              pure (Buffer.releaseThen dOutHeads dQh, dKh, dVh)
+          | .libTorchForward | .composed =>
             let dimsAttn : Array Nat := #[numHeads, n, n]
             let KhT := Buffer.swapAdjacentAtDepth Kh dimsHead depth1
             let scores := Buffer.bmm Qh KhT h32 n32 head32 n32

--- a/NN/Runtime/Autograd/Torch/Core/BackwardOptim.lean
+++ b/NN/Runtime/Autograd/Torch/Core/BackwardOptim.lean
@@ -54,18 +54,57 @@ def backwardScalarDenseAllCuda {α : Type} [CudaBridge.TensorConv α] (s : Eager
   backwardDenseAllCuda (α := α) s (sh := Shape.scalar) loss (Tensor.scalar (1 : α))
 
 /--
-Accumulate one CUDA gradient contribution into a sparse map.
+Array-backed sparse CUDA gradient table indexed by tape node id.
+
+`none` means no cotangent yet. This replaces `HashMap` accumulation on the training hot path: every
+contribution is an `Array.set` instead of a persistent map insert.
+-/
+abbrev CudaGradTable := Array (Option Runtime.Autograd.Cuda.AnyBuffer)
+
+/--
+Accumulate one CUDA gradient contribution into an array-backed sparse table.
 
 Ownership rule: the contribution buffer `g` is consumed by this function. When a contribution is
-first inserted into the map, we store an owned copy and release the incoming buffer. That extra copy
-is intentional: CUDA backward rules are allowed to return a fresh buffer, but view-like rules may
-also pass through an upstream buffer. Copy-on-insert keeps this sparse accumulator correct for every
-op without requiring every local VJP to expose aliasing metadata. When a second contribution arrives,
-we sum into a fresh buffer and release both inputs.
-
-This rule is what lets sparse CUDA backprop avoid the dense "one zero buffer per tape node"
-representation without leaking transient gradients across long training loops.
+first inserted, we store an owned copy and release the incoming buffer. That extra copy is
+intentional: CUDA backward rules are allowed to return a fresh buffer, but view-like rules may also
+pass through an upstream buffer. Copy-on-insert keeps this accumulator correct for every op without
+requiring every local VJP to expose aliasing metadata. When a second contribution arrives, we sum
+into a fresh buffer and release both inputs.
 -/
+def addCudaGradToTable (t : Runtime.Autograd.Cuda.Tape)
+    (gradsRef : IO.Ref CudaGradTable) (id : Nat)
+    (g : Runtime.Autograd.Cuda.AnyBuffer) : IO Unit := do
+  let node ← match t.getNode? id with
+    | some n => pure n
+    | none => throw <| IO.userError "torch: invalid parent id during CUDA backward"
+  if node.requires_grad = false then
+    releaseCudaAnyBuffer g
+  else if _h : g.s = node.value.s then
+    let g' : Runtime.Autograd.Cuda.AnyBuffer := { s := node.value.s, buf := g.buf }
+    let grads ← gradsRef.get
+    match grads[id]? with
+    | none =>
+        releaseCudaAnyBuffer g'
+        throw <| IO.userError "torch: CUDA gradient table out of bounds"
+    | some none =>
+        let owned ← ownedCudaAnyBuffer s!"owned gradient for node {id} ({node.name})" g'
+        releaseCudaAnyBuffer g'
+        gradsRef.set (grads.set! id (some owned))
+    | some (some old) =>
+        if _hold : old.s = node.value.s then
+          let old' : Runtime.Autograd.Cuda.AnyBuffer := { s := node.value.s, buf := old.buf }
+          let summed ← okOrThrow <| Runtime.Autograd.Cuda.AnyBuffer.add old' g'
+          releaseCudaAnyBuffer old'
+          releaseCudaAnyBuffer g'
+          gradsRef.set (grads.set! id (some summed))
+        else
+          releaseCudaAnyBuffer g'
+          throw <| IO.userError "torch: CUDA gradient table has wrong shape for node"
+  else
+    releaseCudaAnyBuffer g
+    throw <| IO.userError "torch: CUDA gradient contribution has wrong shape for parent"
+
+/-- Legacy HashMap accumulator kept for non-training call sites / tests. -/
 def addCudaGradToMap (t : Runtime.Autograd.Cuda.Tape)
     (gradsRef : IO.Ref CudaGradMap) (id : Nat)
     (g : Runtime.Autograd.Cuda.AnyBuffer) : IO Unit := do
@@ -73,11 +112,9 @@ def addCudaGradToMap (t : Runtime.Autograd.Cuda.Tape)
     | some n => pure n
     | none => throw <| IO.userError "torch: invalid parent id during CUDA backward"
   if node.requires_grad = false then
-    checkCudaAnyBufferSize s!"discarded gradient for node {id}" g
     releaseCudaAnyBuffer g
   else if _h : g.s = node.value.s then
     let g' : Runtime.Autograd.Cuda.AnyBuffer := { s := node.value.s, buf := g.buf }
-    checkCudaAnyBufferSize s!"gradient contribution for node {id} ({node.name})" g'
     let grads ← gradsRef.get
     match grads.get? id with
     | none =>
@@ -87,7 +124,6 @@ def addCudaGradToMap (t : Runtime.Autograd.Cuda.Tape)
     | some old =>
         if _hold : old.s = node.value.s then
           let old' : Runtime.Autograd.Cuda.AnyBuffer := { s := node.value.s, buf := old.buf }
-          checkCudaAnyBufferSize s!"accumulated gradient for node {id} ({node.name})" old'
           let summed ← okOrThrow <| Runtime.Autograd.Cuda.AnyBuffer.add old' g'
           releaseCudaAnyBuffer old'
           releaseCudaAnyBuffer g'
@@ -102,8 +138,8 @@ def addCudaGradToMap (t : Runtime.Autograd.Cuda.Tape)
 /--
 Run scalar-loss CUDA backprop and return gradients only for trainable parameter leaves.
 
-The returned map stays on device so CUDA optimizers can update parameters without downloading dense
-gradient arrays to the host.
+Uses an array-backed sparse table during the tape walk (see `CudaGradTable`), then packs only the
+retained parameter gradients into a `CudaGradMap` for the optimizer.
 -/
 def backwardScalarParamGradsCuda {α : Type} [CudaBridge.TensorConv α] (s : EagerSession α)
     [One α] [DecidableEq Shape]
@@ -114,32 +150,43 @@ def backwardScalarParamGradsCuda {α : Type} [CudaBridge.TensorConv α] (s : Eag
   let params ← s.paramsByLeaf.get
   let seedAny ← CudaBridge.TensorConv.toAnyBuffer (α := α) (s := Shape.scalar)
     (Tensor.scalar (1 : α))
-  checkCudaAnyBufferSize "scalar CUDA backward seed" seedAny
-  let gradsRef ← IO.mkRef ((Std.HashMap.emptyWithCapacity).insert loss.id seedAny : CudaGradMap)
-  for off in [0:t.nodes.size] do
-    let id := t.nodes.size - 1 - off
+  let n := t.nodes.size
+  if loss.id ≥ n then
+    releaseCudaAnyBuffer seedAny
+    throw <| IO.userError "torch: scalar CUDA backward seed id out of bounds"
+  let mut table : CudaGradTable := Array.replicate n none
+  table := table.set! loss.id (some seedAny)
+  let gradsRef ← IO.mkRef table
+  for off in [0:n] do
+    let id := n - 1 - off
     let grads ← gradsRef.get
-    match grads.get? id with
-    | none => pure ()
-    | some dLdy =>
+    match grads[id]? with
+    | some (some dLdy) =>
         let node ← match t.getNode? id with
-          | some n => pure n
+          | some node => pure node
           | none => throw <| IO.userError "torch: internal CUDA tape node missing"
         if node.requires_grad then
-          checkCudaAnyBufferSize s!"upstream gradient for node {id} ({node.name})" dLdy
           let contribs ← okOrThrow <| node.backward dLdy
           for (pid, pg) in contribs do
-            addCudaGradToMap t gradsRef pid pg
+            addCudaGradToTable t gradsRef pid pg
         if params.contains id then
           pure ()
         else
           let gradsNow ← gradsRef.get
-          match gradsNow.get? id with
-          | none => pure ()
-          | some stale =>
+          match gradsNow[id]? with
+          | some (some stale) =>
               releaseCudaAnyBuffer stale
-              gradsRef.set (gradsNow.erase id)
-  gradsRef.get
+              gradsRef.set (gradsNow.set! id none)
+          | _ => pure ()
+    | _ => pure ()
+  let final ← gradsRef.get
+  let mut out : CudaGradMap := Std.HashMap.emptyWithCapacity
+  for (id, _p) in params.toList do
+    match final[id]? with
+    | some (some g) => out := out.insert id g
+    | _ =>
+        throw <| IO.userError s!"torch: missing CUDA param gradient for leaf {id}"
+  pure out
 
 /--
 Run reverse-mode backprop and return a dense gradient array for all tape entries.

--- a/NN/Runtime/Autograd/Torch/Core/Ops/Layers.lean
+++ b/NN/Runtime/Autograd/Torch/Core/Ops/Layers.lean
@@ -147,7 +147,8 @@ def multiHeadAttention {α : Type} (s : EagerSession α) [Context α]
     pure { id := id }
   let cuda := do
     let t0 ← s.cudaTape.get
-    let attentionCapsule ← s.selectedCapsule NN.Backend.Attention.scaledDotProductOp
+    -- Prefer LibTorch SDPA on CUDA training (linked by default with `-K cuda=true`).
+    let attentionCapsule := NN.Backend.Attention.libTorchSDPAAutograd
     let (t1, id) ← okOrThrow (Runtime.Autograd.Cuda.Tape.multiHeadAttention (t := t0)
       (n := n) (numHeads := numHeads) (dModel := dModel) (headDim := headDim) (h1 := h1)
       wq.id wk.id wv.id wo.id x.id (mask := mask) (attentionCapsule := attentionCapsule))

--- a/NN/Runtime/Autograd/Torch/Core/Session.lean
+++ b/NN/Runtime/Autograd/Torch/Core/Session.lean
@@ -200,35 +200,43 @@ structure EagerSession (α : Type) where
 
 namespace EagerSession
 
-/-- Select and validate the capsule that corresponds to this eager session's concrete executor. -/
+/-- Select and validate the capsule that corresponds to this eager session's concrete executor.
+
+Caches by `op.name` after the first successful plan+accept so eager training does not re-run
+backend planning / acceptance on every micro-op of every step.
+-/
 def selectedCapsule {α : Type} (s : EagerSession α) (op : NN.Backend.BackendOp) :
     IO NN.Backend.KernelCapsule := do
-  let planned ←
-    match s.opts.planBackendOp op with
-    | .ok planned => pure planned
-    | .error msg => throw <| IO.userError s!"torch: backend planning failed for `{op.name}`: {msg}"
-  let capsule := planned.capsule
-  if s.opts.usesCuda then
-    unless capsule.provider == NN.Backend.Provider.nativeCuda &&
-        capsule.device == NN.Backend.Device.cuda do
-      throw <| IO.userError <|
-        s!"torch: CUDA op `{op.name}` selected capsule `{capsule.name}`, " ++
-          "but this eager path is wired to native CUDA"
-  else
-    unless capsule.provider == NN.Backend.Provider.reference &&
-        capsule.device == NN.Backend.Device.cpu do
-      throw <| IO.userError <|
-        s!"torch: CPU op `{op.name}` selected capsule `{capsule.name}`, " ++
-          "but this eager path is wired to the portable reference provider"
   let selected ← s.selectedBackends.get
-  unless selected.any (fun old => old.capsule.sameIdentity capsule) do
-    s.selectedBackends.set (selected ++ [planned])
-    if s.opts.showBackend then
-      let row := NN.Backend.KernelAudit.ofPlannedKernel
-        { op := planned.op, capsule := planned.capsule }
-      for line in row.detailedReportLines do
-        IO.println line
-  pure capsule
+  match selected.find? (fun old => old.op.name == op.name) with
+  | some cached =>
+      pure cached.capsule
+  | none =>
+      let planned ←
+        match s.opts.planBackendOp op with
+        | .ok planned => pure planned
+        | .error msg =>
+            throw <| IO.userError s!"torch: backend planning failed for `{op.name}`: {msg}"
+      let capsule := planned.capsule
+      if s.opts.usesCuda then
+        unless capsule.provider == NN.Backend.Provider.nativeCuda &&
+            capsule.device == NN.Backend.Device.cuda do
+          throw <| IO.userError <|
+            s!"torch: CUDA op `{op.name}` selected capsule `{capsule.name}`, " ++
+              "but this eager path is wired to native CUDA"
+      else
+        unless capsule.provider == NN.Backend.Provider.reference &&
+            capsule.device == NN.Backend.Device.cpu do
+          throw <| IO.userError <|
+            s!"torch: CPU op `{op.name}` selected capsule `{capsule.name}`, " ++
+              "but this eager path is wired to the portable reference provider"
+      s.selectedBackends.set (selected ++ [planned])
+      if s.opts.showBackend then
+        let row := NN.Backend.KernelAudit.ofPlannedKernel
+          { op := planned.op, capsule := planned.capsule }
+        for line in row.detailedReportLines do
+          IO.println line
+      pure capsule
 
 /-- Accepted capsules actually selected by this eager session. -/
 def backendSelections {α : Type} (s : EagerSession α) : IO (List NN.Backend.AcceptedKernel) :=

--- a/NN/Tests/Backend/Profile.lean
+++ b/NN/Tests/Backend/Profile.lean
@@ -406,8 +406,8 @@ def run : IO Unit := do
   expectCapsules "libtorch forward capsule order" libtorchForward.capsuleNames
     ["libtorch.sdpa_forward"]
   expect "libtorch forward records external boundary" libtorchForward.hasTrustedExternal
-  expect "libtorch forward is test-only runtime support"
-    (libtorchForward.audit.kernels.map (·.runtimeSupport) == [.testOnly])
+  expect "libtorch forward is eager runtime support"
+    (libtorchForward.audit.kernels.map (·.runtimeSupport) == [.eager])
   expectCapsules "libtorch forward external op" libtorchForward.trustedExternalOps
     ["scaled_dot_product_attention"]
   expect "strict gate rejects trusted LibTorch forward"
@@ -419,7 +419,7 @@ def run : IO Unit := do
       expectContains "libtorch forward report names capsule"
         "scaled_dot_product_attention: libtorch.sdpa_forward" report
       expectContains "libtorch forward report names runtime support"
-        "runtime=test-only" report
+        "runtime=eager" report
   | .error msg =>
       throw <| IO.userError s!"libtorch forward report failed: {msg}"
 
@@ -428,8 +428,8 @@ def run : IO Unit := do
   expectCapsules "libtorch autograd capsule order" libtorchAutograd.capsuleNames
     ["libtorch.sdpa_autograd"]
   expect "libtorch autograd records external boundary" libtorchAutograd.hasTrustedExternal
-  expect "libtorch autograd is test-only runtime support"
-    (libtorchAutograd.audit.kernels.map (·.runtimeSupport) == [.testOnly])
+  expect "libtorch autograd is eager runtime support"
+    (libtorchAutograd.audit.kernels.map (·.runtimeSupport) == [.eager])
   expectCapsules "libtorch autograd external op" libtorchAutograd.trustedExternalOps
     ["scaled_dot_product_attention"]
   expect "strict gate rejects trusted LibTorch autograd"
@@ -441,7 +441,7 @@ def run : IO Unit := do
       expectContains "libtorch autograd report names capsule"
         "scaled_dot_product_attention: libtorch.sdpa_autograd" report
       expectContains "libtorch autograd report names runtime support"
-        "runtime=test-only" report
+        "runtime=eager" report
   | .error msg =>
       throw <| IO.userError s!"libtorch autograd report failed: {msg}"
 

--- a/csrc/cuda/kernels/torchlean_libtorch_sdpa.cpp
+++ b/csrc/cuda/kernels/torchlean_libtorch_sdpa.cpp
@@ -127,3 +127,70 @@ extern "C" LEAN_EXPORT lean_obj_res torchlean_libtorch_sdpa_bwd(
     return ioError("LibTorch SDPA backward failed with an unknown native exception");
   }
 }
+
+extern "C" LEAN_EXPORT lean_obj_res torchlean_libtorch_sdpa_fwd_buf(
+    b_lean_obj_arg Q, b_lean_obj_arg K, b_lean_obj_arg V, b_lean_obj_arg M,
+    uint32_t hasMask, uint32_t batch, uint32_t n, uint32_t d, double scale) {
+  try {
+    validateInputs(Q, K, V, M, hasMask, batch, n, d);
+    auto mask = attnMask(M, hasMask, batch, n);
+    auto y = at::scaled_dot_product_attention(view3(Q, batch, n, d), view3(K, batch, n, d),
+                                              view3(V, batch, n, d), mask, 0., false, scale)
+                 .contiguous();
+    auto* out = torchlean_cuda_buffer_alloc((size_t)y.numel());
+    const cudaError_t copy = cudaMemcpy(out->data, y.data_ptr<float>(),
+                                       (size_t)y.numel() * sizeof(float),
+                                       cudaMemcpyDeviceToDevice);
+    if (copy != cudaSuccess) {
+      torchlean_cuda_buffer_drop_unboxed(out);
+      lean_internal_panic((std::string("LibTorch SDPA forward copy failed: ") +
+                           cudaGetErrorString(copy)).c_str());
+    }
+    return torchlean_cuda_buffer_box(out);
+  } catch (const c10::Error& e) {
+    lean_internal_panic((std::string("LibTorch SDPA forward failed: ") +
+                         e.what_without_backtrace()).c_str());
+  } catch (const std::exception& e) {
+    lean_internal_panic((std::string("LibTorch SDPA forward failed: ") + e.what()).c_str());
+  } catch (...) {
+    lean_internal_panic("LibTorch SDPA forward failed with an unknown native exception");
+  }
+}
+
+extern "C" LEAN_EXPORT lean_obj_res torchlean_libtorch_sdpa_bwd_buf(
+    b_lean_obj_arg Q, b_lean_obj_arg K, b_lean_obj_arg V, b_lean_obj_arg M, b_lean_obj_arg DOut,
+    uint32_t hasMask, uint32_t batch, uint32_t n, uint32_t d, double scale) {
+  try {
+    validateInputs(Q, K, V, M, hasMask, batch, n, d, DOut);
+    at::AutoGradMode enable_grad(true);
+    auto mask = attnMask(M, hasMask, batch, n);
+    auto q = view3(Q, batch, n, d).detach().requires_grad_(true);
+    auto k = view3(K, batch, n, d).detach().requires_grad_(true);
+    auto v = view3(V, batch, n, d).detach().requires_grad_(true);
+    auto grad_out = view3(DOut, batch, n, d);
+    auto out = at::scaled_dot_product_attention(q, k, v, mask, 0., false, scale);
+    out.backward(grad_out);
+    const size_t numel = checkedElements(batch, n, d, "gradient");
+    at::Tensor grads[3] = {q.grad(), k.grad(), v.grad()};
+    torchlean_cuda_buffer* bufs[3] = {nullptr, nullptr, nullptr};
+    for (int i = 0; i < 3; ++i) bufs[i] = torchlean_cuda_buffer_alloc(numel);
+    for (int i = 0; i < 3; ++i) {
+      auto t = grads[i].contiguous();
+      const cudaError_t copy = cudaMemcpy(bufs[i]->data, t.data_ptr<float>(),
+                                         numel * sizeof(float), cudaMemcpyDeviceToDevice);
+      if (copy != cudaSuccess) {
+        for (auto* buffer : bufs) torchlean_cuda_buffer_drop_unboxed(buffer);
+        lean_internal_panic((std::string("LibTorch SDPA backward copy failed: ") +
+                             cudaGetErrorString(copy)).c_str());
+      }
+    }
+    return torchlean_cuda_box_three_buffers(bufs[0], bufs[1], bufs[2]);
+  } catch (const c10::Error& e) {
+    lean_internal_panic((std::string("LibTorch SDPA backward failed: ") +
+                         e.what_without_backtrace()).c_str());
+  } catch (const std::exception& e) {
+    lean_internal_panic((std::string("LibTorch SDPA backward failed: ") + e.what()).c_str());
+  } catch (...) {
+    lean_internal_panic("LibTorch SDPA backward failed with an unknown native exception");
+  }
+}

--- a/csrc/cuda/kernels/torchlean_libtorch_sdpa_stub.c
+++ b/csrc/cuda/kernels/torchlean_libtorch_sdpa_stub.c
@@ -1,0 +1,42 @@
+// Stubs when TorchLean is built without `-K libtorch=true`.
+#include <lean/lean.h>
+#include "torchlean_cuda_buffer.h"
+
+static lean_obj_res ioError(const char* message) {
+  return lean_io_result_mk_error(
+      lean_mk_io_error_other_error(1, lean_mk_string(message)));
+}
+
+LEAN_EXPORT lean_obj_res torchlean_libtorch_sdpa_fwd(
+    b_lean_obj_arg Q, b_lean_obj_arg K, b_lean_obj_arg V, b_lean_obj_arg M,
+    uint32_t hasMask, uint32_t batch, uint32_t n, uint32_t d, double scale) {
+  (void)Q; (void)K; (void)V; (void)M; (void)hasMask; (void)batch; (void)n; (void)d; (void)scale;
+  return ioError(
+      "LibTorch SDPA forward unavailable; rebuild with `-K cuda=true -K libtorch=true`");
+}
+
+LEAN_EXPORT lean_obj_res torchlean_libtorch_sdpa_bwd(
+    b_lean_obj_arg Q, b_lean_obj_arg K, b_lean_obj_arg V, b_lean_obj_arg M, b_lean_obj_arg DOut,
+    uint32_t hasMask, uint32_t batch, uint32_t n, uint32_t d, double scale) {
+  (void)Q; (void)K; (void)V; (void)M; (void)DOut; (void)hasMask; (void)batch; (void)n; (void)d;
+  (void)scale;
+  return ioError(
+      "LibTorch SDPA backward unavailable; rebuild with `-K cuda=true -K libtorch=true`");
+}
+
+LEAN_EXPORT lean_obj_res torchlean_libtorch_sdpa_fwd_buf(
+    b_lean_obj_arg Q, b_lean_obj_arg K, b_lean_obj_arg V, b_lean_obj_arg M,
+    uint32_t hasMask, uint32_t batch, uint32_t n, uint32_t d, double scale) {
+  (void)Q; (void)K; (void)V; (void)M; (void)hasMask; (void)batch; (void)n; (void)d; (void)scale;
+  lean_internal_panic(
+      "LibTorch SDPA forward unavailable; rebuild with `-K cuda=true -K libtorch=true`");
+}
+
+LEAN_EXPORT lean_obj_res torchlean_libtorch_sdpa_bwd_buf(
+    b_lean_obj_arg Q, b_lean_obj_arg K, b_lean_obj_arg V, b_lean_obj_arg M, b_lean_obj_arg DOut,
+    uint32_t hasMask, uint32_t batch, uint32_t n, uint32_t d, double scale) {
+  (void)Q; (void)K; (void)V; (void)M; (void)DOut; (void)hasMask; (void)batch; (void)n; (void)d;
+  (void)scale;
+  lean_internal_panic(
+      "LibTorch SDPA backward unavailable; rebuild with `-K cuda=true -K libtorch=true`");
+}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -39,11 +39,17 @@ private def libtorchHomeConfig : Option String :=
       if t.isEmpty then none else some t
   | none => none
 
-/-- Whether to build the optional LibTorch-backed backend capsules. -/
+/-- Whether to build LibTorch-backed capsules.
+
+Default: on whenever `-K cuda=true`, so CUDA training prefers LibTorch SDPA for MHA.
+Disable with `-K libtorch=false` (links the stub; calling SDPA then panics).
+-/
 private def libtorchEnabled : Bool :=
   match get_config? libtorch with
-  | some v => v == "true" || v == "1"
-  | none => false
+  | some "false" | some "0" => false
+  | some "true" | some "1" => true
+  | some _ => false
+  | none => cudaEnabled
 
 /-- Native link flags selected by the `cuda` Lake option. -/
 private def nativeLinkArgs : Array String :=
@@ -158,15 +164,38 @@ private def buildLibtorchSDPASo (pkg : Package) := do
       compileSharedLib soFile (#[o.toString] ++ libtorchSDPALinkArgs lt) "g++"
     return art.path
 
+/-- Always-linked LibTorch SDPA stubs when the real bridge is not enabled. -/
+private def buildLibtorchSDPAStub (pkg : Package) := do
+  let lean ← getLeanInstall
+  let srcJob ← inputFile (pkg.dir / "csrc/cuda/kernels/torchlean_libtorch_sdpa_stub.c") false
+  let oFile := pkg.buildDir / "torchlean_libtorch_sdpa_stub.o"
+  let oJob ← buildO oFile srcJob
+    (#[
+      "-I", lean.includeDir.toString,
+      "-I", s!"{pkg.dir}/csrc/cuda/common",
+      "-O2", "-fPIC"
+    ]) #[] "cc"
+  let libFile := pkg.buildDir / nameToStaticLib "torchlean_libtorch_sdpa_stub"
+  buildStaticLib libFile #[oJob]
+
 target torchlean_libtorch_sdpa_so pkg : FilePath :=
   if cudaEnabled && libtorchEnabled then
     buildLibtorchSDPASo pkg
   else
     pure (Job.pure (pkg.buildDir / "torchlean_libtorch_sdpa_skipped"))
 
+target torchlean_libtorch_sdpa_stub pkg : FilePath :=
+  if cudaEnabled && !libtorchEnabled then
+    buildLibtorchSDPAStub pkg
+  else
+    pure (Job.pure (pkg.buildDir / "torchlean_libtorch_sdpa_stub_skipped"))
+
 @[default_target]
 lean_lib NN where
-  moreLinkObjs := if cudaEnabled && libtorchEnabled then #[torchlean_libtorch_sdpa_so] else #[]
+  moreLinkObjs :=
+    if cudaEnabled && libtorchEnabled then #[torchlean_libtorch_sdpa_so]
+    else if cudaEnabled then #[torchlean_libtorch_sdpa_stub]
+    else #[]
   -- `NN:docs` should document the whole maintained Lean surface, including examples and CLI
   -- dispatchers. Keep tests out of this library surface; they build through `nn_tests_suite`.
   roots := #[


### PR DESCRIPTION
Cache capsule selection, use array grad accum, link LibTorch SDPA by default for CUDA, and initialize token-id LM params storage-first so host materialize is avoided. Small fixes I've run into developing with TorchLean that would let us build and run models as fast as possible with just the --cuda flag.