### PR TITLE
feat(cuda): fused scaledProdExp buffer op — exp((c·x)·y) in one kernel

### DIFF
--- a/NN/Runtime/Autograd/Engine/Cuda/Buffer.lean
+++ b/NN/Runtime/Autograd/Engine/Cuda/Buffer.lean
@@ -540,6 +540,20 @@ opaque adamStep
     (decay updateScale : Float) :
     Buffer × Buffer × Buffer
 
+/--
+Scaled product exponential: `exp((c * x) * y)`, a single fused device kernel — one launch and one
+result buffer instead of the four elementwise ops (`full c`, two `mul`s, `exp`) of the composed form,
+and bit-identical to it (same left-association, same fp32 rounding). `c` is a host `Float` (cast to
+float32); `x` and `y` are equal-length buffers.
+
+Domain-neutral: a *scaled product exponential* recurs across the sciences — a Beer–Lambert /
+propagation two-way extinction `exp(-2 * κ * ℓ)` in computational electromagnetism and radar/optical
+remote sensing, or a Boltzmann-type weight `exp(-β * E * s)`. Fusing the exponential with its scaled
+product is the hot inner form in those forward models.
+-/
+@[never_extract, extern "torchlean_cuda_buffer_scaled_prod_exp"]
+opaque scaledProdExp (x y : @& Buffer) (c : Float) : Buffer
+
 /-- Reductions (return a length-1 buffer). -/
 @[never_extract, extern "torchlean_cuda_buffer_reduce_sum"]
 opaque reduceSum (b : @& Buffer) : Buffer

--- a/NN/Tests/Runtime/Cuda/ScaledProdExp.lean
+++ b/NN/Tests/Runtime/Cuda/ScaledProdExp.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 TorchLean
+Released under MIT license as described in the file LICENSE.
+Authors: TorchLean Team
+-/
+
+module
+
+public import NN.Runtime.Autograd.Engine.Cuda.Buffer
+public import Std
+
+/-!
+# CUDA Kernel Coverage: scaledProdExp (fused scaled product exponential)
+
+`Buffer.scaledProdExp x y c` computes `exp((c · x) · y)` in a single fused device kernel. This test
+pins its defining property: element for element it must be **bit-identical** to the composed form built
+from the elementwise `full` / `mul` / `exp` kernels — `exp(((full c) · x) · y)`, the same
+left-association and the same `expf`. A silent divergence (a fast-math `__expf`, a reassociated
+product, a lost float32 cast) is a regression this catches.
+
+Like the rest of this suite it runs on the CPU stub (`lake build`) and on the GPU (`-K cuda`) alike.
+-/
+
+@[expose] public section
+
+namespace Tests
+namespace Cuda
+namespace ScaledProdExp
+
+open Runtime.Autograd.Cuda
+
+def run : IO Unit := do
+  IO.println "=== CUDA kernel coverage: scaledProdExp (fused vs composed) ==="
+  -- Varied, signed, finite fixtures, kept in a range where `exp` stays finite.
+  let xs : FloatArray := FloatArray.mk #[0.10, -0.20, 0.35, -0.50, 0.75, -0.90, 0.00, 1.00, -1.00, 0.42]
+  let ys : FloatArray := FloatArray.mk #[0.90, -0.75, 0.50, -0.30, 0.15, -0.05, 1.00, -1.00, 0.25, -0.60]
+  let n : UInt32 := xs.size.toUInt32
+  let x := Buffer.ofFloatArray xs
+  let y := Buffer.ofFloatArray ys
+  -- Scalars spanning sign and magnitude, including the identity `c = 0`.
+  for c in (#[-2.0, 0.5, 3.25, -0.125, 1.0, 0.0] : Array Float) do
+    let fused    := Buffer.scaledProdExp x y c
+    let composed := Buffer.exp (Buffer.mul (Buffer.mul (Buffer.full n c) x) y)
+    let af := Buffer.toFloatArray fused
+    let ac := Buffer.toFloatArray composed
+    if af.size != ac.size then
+      throw <| IO.userError s!"scaledProdExp c={c}: size mismatch ({af.size} vs {ac.size})"
+    let mut mism : Nat := 0
+    let mut maxDiff : Float := 0.0
+    for i in [:af.size] do
+      let vf := af.get! i
+      let vc := ac.get! i
+      -- Bit-level comparison: `toBits` distinguishes results that `==` would call equal.
+      if vf.toBits != vc.toBits then mism := mism + 1
+      let d := Float.abs (vf - vc)
+      if d > maxDiff then maxDiff := d
+    if mism != 0 then
+      throw <| IO.userError
+        s!"scaledProdExp c={c}: {mism}/{af.size} elements differ from composed exp((c·x)·y) (max |Δ|={maxDiff})"
+  IO.println "  fused scaledProdExp bit-identical to composed exp((c·x)·y) over all fixtures ✓"
+
+end ScaledProdExp
+end Cuda
+end Tests

--- a/NN/Tests/Runtime/Cuda/Suite.lean
+++ b/NN/Tests/Runtime/Cuda/Suite.lean
@@ -21,6 +21,7 @@ public import NN.Tests.Runtime.Cuda.Matmul
 public import NN.Tests.Runtime.Cuda.Fft
 public import NN.Tests.Runtime.Cuda.ViewsBroadcastReduce
 public import NN.Tests.Runtime.Cuda.LinearMseConcatSliceGather
+public import NN.Tests.Runtime.Cuda.ScaledProdExp
 public import NN.Tests.Runtime.Cuda.Stress
 
 /-!
@@ -56,6 +57,7 @@ def run : IO Unit := do
   Fft.run
   ViewsBroadcastReduce.run
   LinearMseConcatSliceGather.run
+  ScaledProdExp.run
   Stress.run
   IO.println "=== CUDA kernel coverage suite completed ==="
 

--- a/csrc/cuda/tensor/torchlean_cuda_tensor.cu
+++ b/csrc/cuda/tensor/torchlean_cuda_tensor.cu
@@ -519,6 +519,16 @@ __global__ void torchlean_mul_f32(const float* a, const float* b, float* out, si
   }
 }
 
+// Scaled product exponential `exp((c*a)*b)` fused into one kernel (one launch, one result
+// buffer) instead of the four elementwise ops of the composed form. Left-associated and in fp32
+// throughout, so it is bit-identical to `exp(mul(mul(full(c), a), b))`.
+__global__ void torchlean_scaled_prod_exp_f32(const float* a, const float* b, float* out, size_t n,
+                                              float c) {
+  TORCHLEAN_GRID_STRIDE_LOOP(i, n) {
+    out[i] = expf((c * a[i]) * b[i]);
+  }
+}
+
 __global__ void torchlean_scale_f32(const float* in, float* out, size_t n, float c) {
   TORCHLEAN_GRID_STRIDE_LOOP(i, n) {
     out[i] = in[i] * c;
@@ -1544,6 +1554,9 @@ extern "C" LEAN_EXPORT lean_obj_res torchlean_cuda_buffer_adam_step(
   return torchlean_cuda_box_three_buffers(
       updated_parameters, updated_first_moment, updated_second_moment);
 }
+
+TORCHLEAN_DEFINE_BINARY_SCALAR_BUFFER_EXPORT(torchlean_cuda_buffer_scaled_prod_exp,
+                                             torchlean_scaled_prod_exp_f32, "scaled_prod_exp")
 
 #undef TORCHLEAN_DEFINE_BINARY_SCALAR_BUFFER_EXPORT
 #undef TORCHLEAN_DEFINE_UNARY_SCALAR_BUFFER_EXPORT

--- a/csrc/cuda/tensor/torchlean_cuda_tensor_stub.c
+++ b/csrc/cuda/tensor/torchlean_cuda_tensor_stub.c
@@ -811,6 +811,19 @@ LEAN_EXPORT lean_obj_res torchlean_cuda_buffer_adam_step(
       updated_parameters, updated_first_moment, updated_second_moment);
 }
 
+LEAN_EXPORT lean_obj_res torchlean_cuda_buffer_scaled_prod_exp(b_lean_obj_arg AObj,
+                                                              b_lean_obj_arg BObj, double c) {
+  torchlean_cuda_buffer* a = torchlean_cuda_buffer_unbox(AObj);
+  torchlean_cuda_buffer* b = torchlean_cuda_buffer_unbox(BObj);
+  torchlean_cuda_require_same_size2(a, b, "torchlean_cuda_buffer_scaled_prod_exp_stub");
+  torchlean_cuda_buffer* out = torchlean_cuda_buffer_alloc(a->size);
+  float fc = (float)c;
+  for (size_t i = 0; i < a->size; ++i) {
+    out->data[i] = expf((fc * a->data[i]) * b->data[i]);
+  }
+  return torchlean_cuda_buffer_box(out);
+}
+
 LEAN_EXPORT lean_obj_res torchlean_cuda_buffer_reduce_sum(b_lean_obj_arg BObj) {
   torchlean_cuda_buffer* b = torchlean_cuda_buffer_unbox(BObj);
   torchlean_cuda_buffer* out = torchlean_cuda_buffer_alloc(1);


### PR DESCRIPTION
`Buffer.scaledProdExp x y c` computes `exp((c·x)·y)` as a single fused elementwise device kernel (`torchlean_scaled_prod_exp_f32`, exported via the existing binary+scalar macro), with a portable host-loop stub twin. It computes in fp32 with the same left-association as the composed `exp(mul(mul(full(c), x), y))`, so it is **bit-identical** to that four-op form while issuing one launch and allocating one result buffer instead of four.

### Motivation

A *scaled product exponential* is the hot inner form of two-way extinction / propagation factors `exp(-2·κ·ℓ)` in computational electromagnetism and radar/optical remote sensing, and of Boltzmann-type weights `exp(-β·E·s)`. It names no problem domain — a portable primitive a batched pipeline can fuse.

### Tests

`NN/Tests/Runtime/Cuda/ScaledProdExp.lean` (wired into the CUDA coverage suite) asserts the fused kernel is bit-identical to the composed `exp(((full c)·x)·y)` — compared by `Float.toBits`, not a tolerance — across signed/zero fixtures and a range of scalars. A fast-math `__expf`, a reassociated product, or a dropped float32 cast would fail it. Like the rest of the suite it runs on the CPU stub (`lake build`) and on the GPU (`-K cuda`) alike.

### Verification

- `nvcc` compiles the kernel; `cc` compiles the stub; the `@[extern]` binding elaborates.
- `nn_tests_suite -K cuda=true` is green on an RTX A4500; the parity test above passes.
