### PR TITLE
feat(cuda): TexTable — layered 1-D lookup-table textures with point/hardware filtering

### DIFF
--- a/NN/Runtime/Autograd/Engine/Cuda.lean
+++ b/NN/Runtime/Autograd/Engine/Cuda.lean
@@ -18,6 +18,7 @@ public import NN.Runtime.Autograd.Engine.Cuda.NativeSources
 public import NN.Runtime.Autograd.Engine.Cuda.Ops
 public import NN.Runtime.Autograd.Engine.Cuda.Shape
 public import NN.Runtime.Autograd.Engine.Cuda.Tape
+public import NN.Runtime.Autograd.Engine.Cuda.TexTable
 public import NN.Runtime.Autograd.Engine.Cuda.Trusted
 
 /-!

--- a/NN/Runtime/Autograd/Engine/Cuda/KernelSpec.lean
+++ b/NN/Runtime/Autograd/Engine/Cuda/KernelSpec.lean
@@ -298,6 +298,26 @@ def gatherThenScatterToZeroSpec {n k : Nat} (x : FlatBuffer n) (idx : Fin k → 
     FlatBuffer n :=
   scatterAddSpec (fun _ => IEEE32Exec.posZero) (gatherVecSpec x idx) idx
 
+/-! ## Lookup-table texture lerp -/
+
+/--
+Pure spec for the lookup-table fetch of `NN.Runtime.Autograd.Engine.Cuda.TexTable` in *point*
+mode, after coordinate decomposition: given a layered table, per-element layer selections, the
+two proof-carrying sample indices `j`/`j'` (the clamped `⌊u⌋` and `⌊u⌋+1`), and the float32
+fractional weight `f = u − ⌊u⌋`, each output is the guarded float32 lerp
+`tab[L][j] + f · (tab[L][j'] − tab[L][j])`.
+
+The coordinate decomposition itself (clamping `u` to `[0, width−1]`, `floor`, the exactness of
+`u − ⌊u⌋` in float32) and hardware mode's 9-bit weight quantization live at the native trust
+boundary; both are validated bit-level by the executable `Float32` parity tests in
+`NN.Tests.Runtime.Cuda.TexTable`, per this file's three-layer split.
+-/
+def texLerpSpec {w l k : Nat} (tab : Fin l → Fin w → RefScalar)
+    (layer : Fin k → Fin l) (j j' : Fin k → Fin w) (f : Fin k → RefScalar) : FlatBuffer k :=
+  fun i =>
+    IEEE32Exec.add (tab (layer i) (j i))
+      (IEEE32Exec.mul (f i) (IEEE32Exec.sub (tab (layer i) (j' i)) (tab (layer i) (j i))))
+
 /-! ## Batched row-major matrix multiplication -/
 
 /-- Linear row-major index for `A[b, i, k]` with shape `(batch, m, n)`. -/

--- a/NN/Runtime/Autograd/Engine/Cuda/NativeSources.lean
+++ b/NN/Runtime/Autograd/Engine/Cuda/NativeSources.lean
@@ -99,6 +99,21 @@ agrees with CPU stubs and reference cases on the supported path.
 - `csrc/cuda/blas/torchlean_dgemm_cuda_stub.c`
   Portable CPU mirror of the DGEMM FFI symbol.
 
+- `csrc/cuda/common/torchlean_cuda_textable.h`
+  Boxed ABI for immutable layered 1-D lookup-table textures (float32) and their fetch/metadata
+  symbol declarations.
+  Lean side modules: `NN.Runtime.Autograd.Engine.Cuda.Trusted`,
+  `NN.Runtime.Autograd.Engine.Cuda.TexTable`.
+
+- `csrc/cuda/textures/torchlean_cuda_textable.cu`
+  Layered `cudaArray` + texture-object construction and the interpolated fetch kernel (point mode
+  with an explicit contraction-blocked lerp, or hardware linear filtering).
+  Lean side module: `NN.Runtime.Autograd.Engine.Cuda.TexTable`.
+
+- `csrc/cuda/textures/torchlean_cuda_textable_stub.c`
+  Portable CPU mirror of the lookup-table texture FFI surface; point mode is bit-identical to the
+  CUDA kernel, hardware mode emulates the 9-bit lerp weight.
+
 ## What to read next
 
 - `NN.Runtime.Autograd.Engine.Cuda.Float32Contract` states the float32 agreement assumptions.

--- a/NN/Runtime/Autograd/Engine/Cuda/TexTable.lean
+++ b/NN/Runtime/Autograd/Engine/Cuda/TexTable.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 TorchLean
+Released under MIT license as described in the file LICENSE.
+Authors: TorchLean Team
+
+Layered 1-D lookup-table textures (float32).
+
+Implementation:
+- CUDA: `csrc/cuda/textures/torchlean_cuda_textable.cu`
+- CPU stub (default `lake build`): `csrc/cuda/textures/torchlean_cuda_textable_stub.c`
+-/
+
+module
+
+public import NN.Runtime.Autograd.Engine.Cuda.Trusted
+public import NN.Runtime.Autograd.Engine.Cuda.Buffer
+
+@[expose] public section
+
+namespace Runtime
+namespace Autograd
+namespace Cuda
+
+namespace TexTable
+
+/-!
+# Lookup-table textures
+
+A `TexTable` holds a small, immutable, *layered* 1-D table of float32 samples over a uniform
+abscissa — tabulated transfer functions, calibration curves, and similar tabulated 1-D functions
+whose analytic form is expensive or unavailable (common in signal processing and radar/optical
+remote sensing). On the CUDA build it is backed by a layered `cudaArray` bound to a texture
+object, so fetches go through the GPU's dedicated texture cache; the default build uses a
+host-memory parity stub.
+
+## Coordinate convention
+
+`fetch` evaluates the table by piecewise-linear interpolation at *grid-space* coordinates
+`u ∈ [0, width − 1]` (unnormalized; clamped at both ends), in the layer selected by an
+integral-valued float index (clamped to `[0, layers − 1]`; layers are **not** interpolated
+across). With `i = ⌊clamp(u, 0, width−1)⌋` and `f = u − i`, the result is
+`table[layer][i] + f · (table[layer][i+1] − table[layer][i])` — the uniform-grid analogue of
+`np.interp`. The native kernels add any texel-center offset internally; callers never add `0.5`.
+
+## Filter modes (fixed at construction)
+
+- `hwFilter := false` (**point mode**, default): two point fetches plus an explicit float32 lerp.
+  Bit-reproducible — the CUDA build and the CPU stub return identical float32 results.
+- `hwFilter := true` (**hardware mode**): the texture unit interpolates in hardware at zero ALU
+  cost. CUDA specifies a 9-bit fixed-point lerp weight (8 fractional bits), so results carry a
+  weight-quantization error of at most `2⁻⁸ · |table[i+1] − table[i]|` per fetch and must be
+  compared by tolerance; the stub emulates the quantized weight.
+
+Tables are forward-only values: fetches record no tape and define no gradient.
+-/
+
+/--
+Build a table from `layers * width` samples in layer-major order (row `l` occupies
+`data[l*width ..< (l+1)*width]`), narrowed to float32. Panics unless `width ≥ 1`, `layers ≥ 1`,
+and `data.size = layers * width`.
+-/
+@[extern "torchlean_cuda_textable_make"]
+opaque ofFloatArray (data : @& FloatArray) (width layers : @& Nat) (hwFilter : Bool := false) :
+  TexTable
+
+/-- Samples per layer. -/
+@[extern "torchlean_cuda_textable_width"]
+opaque width (t : @& TexTable) : Nat
+
+/-- Number of layers. -/
+@[extern "torchlean_cuda_textable_layers"]
+opaque layers (t : @& TexTable) : Nat
+
+/-- `true` iff the table was built with hardware filtering (`hwFilter := true`). -/
+@[extern "torchlean_cuda_textable_filter_hw"]
+opaque filterHw (t : @& TexTable) : Bool
+
+/--
+Evaluate the table at per-element grid coordinates `coords` (clamped to `[0, width − 1]`) in the
+layers selected by `layerIdx` (integral-valued float32 indices, clamped to `[0, layers − 1]`).
+`coords` and `layerIdx` must have equal sizes; the result is a fresh buffer of that size.
+-/
+@[extern "torchlean_cuda_textable_fetch"]
+opaque fetch (t : @& TexTable) (coords layerIdx : @& Buffer) : Buffer
+
+end TexTable
+
+end Cuda
+end Autograd
+end Runtime

--- a/NN/Runtime/Autograd/Engine/Cuda/Trusted.lean
+++ b/NN/Runtime/Autograd/Engine/Cuda/Trusted.lean
@@ -51,6 +51,26 @@ def Buffer : Type := BufferImpl.val
 
 instance : Nonempty Buffer := BufferImpl.property
 
+/--
+Opaque handle to an immutable, layered 1-D lookup table of float32 samples (a CUDA texture object
+over a layered `cudaArray` when built with `-K cuda=true`, otherwise a CPU stub table).
+
+Implementation:
+- CUDA: `csrc/cuda/textures/torchlean_cuda_textable.cu`
+- CPU stub (default `lake build`): `csrc/cuda/textures/torchlean_cuda_textable_stub.c`
+-/
+opaque TexTableImpl : NonemptyType.{0}
+
+/--
+Runtime representation used for native lookup-table texture handles.
+
+As with `Buffer`, the `NonemptyType` wrapper only gives extern declarations a nonempty result
+type; values are created only by the native table constructor.
+-/
+def TexTable : Type := TexTableImpl.val
+
+instance : Nonempty TexTable := TexTableImpl.property
+
 end Cuda
 end Autograd
 end Runtime

--- a/NN/Tests/Runtime/Cuda/Suite.lean
+++ b/NN/Tests/Runtime/Cuda/Suite.lean
@@ -21,6 +21,7 @@ public import NN.Tests.Runtime.Cuda.Matmul
 public import NN.Tests.Runtime.Cuda.Fft
 public import NN.Tests.Runtime.Cuda.ViewsBroadcastReduce
 public import NN.Tests.Runtime.Cuda.LinearMseConcatSliceGather
+public import NN.Tests.Runtime.Cuda.TexTable
 public import NN.Tests.Runtime.Cuda.Stress
 
 /-!
@@ -56,6 +57,7 @@ def run : IO Unit := do
   Fft.run
   ViewsBroadcastReduce.run
   LinearMseConcatSliceGather.run
+  TexTable.run
   Stress.run
   IO.println "=== CUDA kernel coverage suite completed ==="
 

--- a/NN/Tests/Runtime/Cuda/TexTable.lean
+++ b/NN/Tests/Runtime/Cuda/TexTable.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 TorchLean
+Released under MIT license as described in the file LICENSE.
+Authors: TorchLean Team
+-/
+
+module
+
+public import NN.Runtime.Autograd.Engine.Cuda.Buffer
+public import NN.Runtime.Autograd.Engine.Cuda.TexTable
+public import NN.Tests.Runtime.Cuda.Utils
+
+/-!
+# CUDA Kernel Coverage: Lookup-Table Textures
+
+Validates `Runtime.Autograd.Cuda.TexTable` against an executable `Float32` reference:
+
+- **point mode** must match the reference **bit-for-bit** in both builds (the CPU stub and the
+  CUDA kernel evaluate the same clamp/floor/lerp in float32 with FMA contraction blocked);
+- **hardware mode** is compared by tolerance (`2⁻⁸` of the local sample gap): CUDA's texture unit
+  uses a 9-bit fixed-point lerp weight whose rounding is unspecified;
+- **integer-node fetches** must be bit-exact in *both* modes (the lerp weight is exactly 0 there) —
+  this probe catches any texel-center (`±0.5`) coordinate-convention error;
+- edge behavior: clamping below/above the abscissa range, layer-index clamping, `width = 1`,
+  and empty coordinate buffers.
+-/
+
+@[expose] public section
+
+namespace Tests
+namespace Cuda
+namespace TexTable
+
+open Runtime.Autograd.Cuda
+
+/-- Float32 clamp mirroring the native kernels' `fminf(fmaxf(u, 0), wmax)`. -/
+def clampF32 (x lo hi : Float32) : Float32 :=
+  if x < lo then lo else if x > hi then hi else x
+
+/--
+Executable reference for `TexTable.fetch`, computed in Lean core `Float32` (IEEE binary32, the
+same arithmetic as the native kernels). Mirrors the CPU stub statement-for-statement; in point
+mode the CUDA kernel is bit-identical by construction, in hardware mode the CUDA texture unit may
+round the 9-bit weight differently (hence tolerance).
+-/
+def refFetch (tab : Array Float32) (width layers : Nat) (hw : Bool)
+    (u layer : Float32) : Float32 :=
+  let wmax : Float32 := Float32.ofNat (width - 1)
+  let uc := clampF32 u 0.0 wmax
+  let lF := clampF32 (layer + 0.5) 0.0 (Float32.ofNat (layers - 1))
+  let L := lF.toFloat.toUInt64.toNat
+  let j := uc.floor
+  let f := uc - j
+  let f := if hw then Float32.floor (f * 256.0 + 0.5) / 256.0 else f
+  let j0 := j.toFloat.toUInt64.toNat
+  let j1 := if j0 + 1 < width then j0 + 1 else width - 1
+  let a := tab[L * width + j0]!
+  let b := tab[L * width + j1]!
+  a + f * (b - a)
+
+/-- The float64 sample grid used by every test below (3 layers × 7 samples, non-trivial values). -/
+def sampleData (width layers : Nat) : FloatArray := Id.run do
+  let mut a := FloatArray.emptyWithCapacity (width * layers)
+  for l in [0:layers] do
+    for i in [0:width] do
+      let x := Float.ofNat i
+      let y := Float.ofNat l
+      a := a.push (0.17 * x - 0.031 * x * x + 0.4 * y + 0.05)
+  return a
+
+/-- Run one fetch through the native path and the reference, returning both as `Float32`. -/
+def runFetch (t : TexTable) (tab32 : Array Float32) (width layers : Nat) (hw : Bool)
+    (coords layerIdx : FloatArray) : IO (Array Float32 × Array Float32) := do
+  let out := Buffer.toFloatArray
+    (Runtime.Autograd.Cuda.TexTable.fetch t (Buffer.ofFloatArray coords)
+      (Buffer.ofFloatArray layerIdx))
+  let mut native : Array Float32 := #[]
+  let mut refv : Array Float32 := #[]
+  for i in [0:out.size] do
+    native := native.push (out[i]!).toFloat32
+    refv := refv.push
+      (refFetch tab32 width layers hw (coords[i]!).toFloat32 (layerIdx[i]!).toFloat32)
+  return (native, refv)
+
+/-- Assert bitwise equality of native and reference results. -/
+def assertBits (msg : String) (native refv : Array Float32) : IO Unit := do
+  for i in [0:native.size] do
+    let x := native[i]!
+    let y := refv[i]!
+    unless x.toBits == y.toBits do
+      throw <| IO.userError
+        s!"{msg}[{i}]: native {x} (bits {x.toBits}) ≠ reference {y} (bits {y.toBits})"
+
+/-- Assert tolerance agreement of native and reference results. -/
+def assertTol (msg : String) (native refv : Array Float32) (tol : Float) : IO Unit := do
+  for i in [0:native.size] do
+    let x := (native[i]!).toFloat
+    let y := (refv[i]!).toFloat
+    Utils.assertApprox s!"{msg}[{i}]" x y (tol := tol)
+
+def widthN : Nat := 7
+def layersN : Nat := 3
+
+/-- Interior, boundary, and out-of-range grid coordinates across all layers. -/
+def probeCoords : FloatArray :=
+  FloatArray.mk #[0.0, 0.25, 1.0, 2.5, 3.75, 5.999, 6.0, -1.5, 9.75, 4.125, 2.875, 0.001]
+
+def probeLayers : FloatArray :=
+  FloatArray.mk #[0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2]
+
+def runPointMode : IO Unit := do
+  IO.println "== textable point mode (bit-exact) =="
+  let data := sampleData widthN layersN
+  let tab32 := (Array.range data.size).map fun i => (data[i]!).toFloat32
+  let t := Runtime.Autograd.Cuda.TexTable.ofFloatArray data widthN layersN (hwFilter := false)
+  unless Runtime.Autograd.Cuda.TexTable.width t == widthN &&
+      Runtime.Autograd.Cuda.TexTable.layers t == layersN &&
+      Runtime.Autograd.Cuda.TexTable.filterHw t == false do
+    throw <| IO.userError "textable point: metadata mismatch"
+  let (native, refv) ← runFetch t tab32 widthN layersN false probeCoords probeLayers
+  assertBits "textable point" native refv
+
+def runHardwareMode : IO Unit := do
+  IO.println "== textable hardware mode (tolerance) =="
+  let data := sampleData widthN layersN
+  let tab32 := (Array.range data.size).map fun i => (data[i]!).toFloat32
+  let t := Runtime.Autograd.Cuda.TexTable.ofFloatArray data widthN layersN (hwFilter := true)
+  unless Runtime.Autograd.Cuda.TexTable.filterHw t == true do
+    throw <| IO.userError "textable hw: metadata mismatch"
+  let (native, refv) ← runFetch t tab32 widthN layersN true probeCoords probeLayers
+  -- Weight quantization bounds the error by 2⁻⁸ · max |Δ sample| (≈ 0.17 here), plus slack for
+  -- the unspecified hardware weight rounding.
+  assertTol "textable hw" native refv (tol := 2.0e-3)
+
+/-- Integer-node fetches return stored samples bit-exactly in both modes (texel-center probe). -/
+def runIntegerNodes : IO Unit := do
+  IO.println "== textable integer nodes (bit-exact, both modes) =="
+  let data := sampleData widthN layersN
+  let mut coords : FloatArray := FloatArray.emptyWithCapacity (widthN * layersN)
+  let mut lidx : FloatArray := FloatArray.emptyWithCapacity (widthN * layersN)
+  for l in [0:layersN] do
+    for i in [0:widthN] do
+      coords := coords.push (Float.ofNat i)
+      lidx := lidx.push (Float.ofNat l)
+  for hw in [false, true] do
+    let t := Runtime.Autograd.Cuda.TexTable.ofFloatArray data widthN layersN (hwFilter := hw)
+    let out := Buffer.toFloatArray
+      (Runtime.Autograd.Cuda.TexTable.fetch t (Buffer.ofFloatArray coords)
+        (Buffer.ofFloatArray lidx))
+    for i in [0:out.size] do
+      let got := (out[i]!).toFloat32
+      let want := (data[i]!).toFloat32
+      unless got.toBits == want.toBits do
+        throw <| IO.userError
+          s!"textable integer node (hw={hw})[{i}]: got {got}, want stored sample {want}"
+
+def runEdges : IO Unit := do
+  IO.println "== textable edges (width=1, layer clamp, empty) =="
+  -- width = 1: every coordinate hits the single sample.
+  let one := FloatArray.mk #[0.75, -0.75]
+  let t1 := Runtime.Autograd.Cuda.TexTable.ofFloatArray one 1 2 (hwFilter := false)
+  let outs := Buffer.toFloatArray
+    (Runtime.Autograd.Cuda.TexTable.fetch t1
+      (Buffer.ofFloatArray (FloatArray.mk #[0.0, 3.5, -2.0]))
+      (Buffer.ofFloatArray (FloatArray.mk #[0, 0, 1])))
+  let expect : Array Float := #[0.75, 0.75, -0.75]
+  for i in [0:outs.size] do
+    unless ((outs[i]!).toFloat32).toBits == ((expect[i]!).toFloat32).toBits do
+      throw <| IO.userError s!"textable width=1[{i}]: got {outs[i]!}, want {expect[i]!}"
+  -- layer index out of range clamps to the last layer.
+  let outc := Buffer.toFloatArray
+    (Runtime.Autograd.Cuda.TexTable.fetch t1
+      (Buffer.ofFloatArray (FloatArray.mk #[0.0]))
+      (Buffer.ofFloatArray (FloatArray.mk #[7.0])))
+  unless ((outc[0]!).toFloat32).toBits == ((-0.75 : Float).toFloat32).toBits do
+    throw <| IO.userError s!"textable layer clamp: got {outc[0]!}, want -0.75"
+  -- empty coordinate buffer yields an empty result.
+  let oute := Buffer.toFloatArray
+    (Runtime.Autograd.Cuda.TexTable.fetch t1
+      (Buffer.ofFloatArray (FloatArray.mk #[]))
+      (Buffer.ofFloatArray (FloatArray.mk #[])))
+  unless oute.size == 0 do
+    throw <| IO.userError s!"textable empty: expected empty result, got size {oute.size}"
+
+/-- Unified TexTable test entrypoint. -/
+def run : IO Unit := do
+  runPointMode
+  runHardwareMode
+  runIntegerNodes
+  runEdges
+
+end TexTable
+end Cuda
+end Tests

--- a/csrc/cuda/README.md
+++ b/csrc/cuda/README.md
@@ -136,6 +136,7 @@ Current CUDA coverage:
 | `NN/Tests/Runtime/Cuda/Fft.lean` | Packed real FFT, inverse FFT, spectral convolution, and finite-difference gradient checks. |
 | `NN/Tests/Runtime/Cuda/ViewsBroadcastReduce.lean` | Reshape, transpose, rank-3 permutations, broadcast, reduce-sum/mean, and empty-axis behavior. |
 | `NN/Tests/Runtime/Cuda/LinearMseConcatSliceGather.lean` | Linear layer, MSE loss, vector concat/slice, scalar gather, row gather, and gradients. |
+| `NN/Tests/Runtime/Cuda/TexTable.lean` | Layered 1-D lookup-table textures: bit-exact point-mode lerp, tolerance-gated hardware filtering, integer-node texel-center probes, clamping and empty-buffer edges. |
 | `NN/Tests/Runtime/Cuda/Stress.lean` | RNG determinism, explicit buffer release, duplicate-parent gradient accumulation, large buffers, reductions, and cuBLAS rectangular matmul. |
 | `NN/Tests/Runtime/Cuda/Suite.lean` | The unified entrypoint imported by the repository-level test suite. |
 

--- a/csrc/cuda/common/torchlean_cuda_textable.h
+++ b/csrc/cuda/common/torchlean_cuda_textable.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <lean/lean.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "torchlean_cuda_buffer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Layered 1-D lookup-table textures (float32).
+//
+// This header is the native side of `NN.Runtime.Autograd.Engine.Cuda.TexTable`.
+// A `torchlean_cuda_textable` holds a small, immutable, layered 1-D table of float32 samples over a
+// uniform abscissa, evaluated by piecewise-linear interpolation at grid-space coordinates
+// `u ∈ [0, width−1]` (clamped). Typical uses are tabulated transfer functions and calibration
+// curves whose analytic form is expensive or unavailable.
+//
+// Two filter modes are fixed at construction:
+// - `filter_mode == 0` (point): two point fetches plus an explicit float32 lerp. This mode is
+//   bit-reproducible: the CUDA build and the CPU stub compute identical float32 results.
+// - `filter_mode == 1` (hardware): the GPU texture unit interpolates in hardware. CUDA specifies a
+//   9-bit fixed-point fraction (8 fractional bits) for the lerp weight, so results are only
+//   approximate; the CPU stub emulates the quantized weight and callers must compare by tolerance.
+//
+// Ownership/ABI:
+// - Lean owns an external object that points at `torchlean_cuda_textable`;
+// - `host` is always a private float32 copy of the samples (`layers * width` elements, layer-major);
+// - in the CUDA build `cuarray`/`tex` hold the `cudaArray_t` and `cudaTextureObject_t`; the CPU
+//   stub leaves them NULL/0;
+// - tables are immutable after construction; the finalizer releases every resource.
+//
+// This is a trusted boundary, like `torchlean_cuda_buffer.h`.
+
+typedef struct {
+  size_t width;        // samples per layer (>= 1)
+  size_t layers;       // number of layers (>= 1)
+  uint32_t filter_mode;  // 0 = point + explicit lerp (bit-reproducible), 1 = hardware linear
+  float* host;         // private float32 copy, layers*width, layer-major
+  void* cuarray;       // CUDA build: cudaArray_t; NULL in the CPU stub
+  unsigned long long tex;  // CUDA build: cudaTextureObject_t; 0 in the CPU stub
+} torchlean_cuda_textable;
+
+// Helpers implemented by `torchlean_cuda_textable.cu` / `torchlean_cuda_textable_stub.c`.
+torchlean_cuda_textable* torchlean_cuda_textable_unbox(b_lean_obj_arg obj);
+lean_obj_res torchlean_cuda_textable_box(torchlean_cuda_textable* t);
+
+// Construct a table from a Lean `FloatArray` of `layers * width` samples (layer-major, narrowed to
+// float32). Panics unless `width >= 1`, `layers >= 1`, and the array has exactly `layers * width`
+// entries.
+LEAN_EXPORT lean_obj_res torchlean_cuda_textable_make(b_lean_obj_arg data, b_lean_obj_arg width,
+                                                      b_lean_obj_arg layers, uint8_t hw_filter);
+
+// Evaluate the table at per-element grid coordinates `coords` (clamped to `[0, width−1]`) in the
+// layer selected by `layer_idx` (integral-valued float32 indices, clamped to `[0, layers−1]`).
+// `coords` and `layer_idx` must have equal sizes; returns a new buffer of that size.
+LEAN_EXPORT lean_obj_res torchlean_cuda_textable_fetch(b_lean_obj_arg tbl, b_lean_obj_arg coords,
+                                                       b_lean_obj_arg layer_idx);
+
+// Metadata accessors.
+LEAN_EXPORT lean_obj_res torchlean_cuda_textable_width(b_lean_obj_arg tbl);
+LEAN_EXPORT lean_obj_res torchlean_cuda_textable_layers(b_lean_obj_arg tbl);
+LEAN_EXPORT uint8_t torchlean_cuda_textable_filter_hw(b_lean_obj_arg tbl);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif

--- a/csrc/cuda/textures/torchlean_cuda_textable.cu
+++ b/csrc/cuda/textures/torchlean_cuda_textable.cu
@@ -1,0 +1,211 @@
+// CUDA implementation of layered 1-D lookup-table textures (float32).
+//
+// See `csrc/cuda/common/torchlean_cuda_textable.h` for the ABI and semantics contract, and
+// `csrc/cuda/textures/torchlean_cuda_textable_stub.c` for the portable CPU twin. Every exported
+// symbol here must exist in the stub with the same name and signature.
+
+#include <lean/lean.h>
+
+#include "torchlean_cuda_buffer.h"
+#include "torchlean_cuda_common.h"
+#include "torchlean_cuda_textable.h"
+
+#include <cuda_runtime.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// --- External object plumbing ------------------------------------------------
+
+static void torchlean_cuda_textable_finalize(void* ptr) {
+  torchlean_cuda_textable* t = (torchlean_cuda_textable*)ptr;
+  if (!t) {
+    return;
+  }
+  if (t->tex != 0) {
+    (void)cudaDestroyTextureObject((cudaTextureObject_t)t->tex);
+  }
+  if (t->cuarray) {
+    (void)cudaFreeArray((cudaArray_t)t->cuarray);
+  }
+  free(t->host);
+  free(t);
+}
+
+// `torchlean_cuda_textable` holds no Lean references.
+static void torchlean_cuda_textable_foreach(void* _ptr, b_lean_obj_arg _fn) {
+  (void)_ptr;
+  (void)_fn;
+}
+
+static lean_external_class* torchlean_cuda_textable_class = NULL;
+
+static lean_external_class* torchlean_cuda_textable_get_class(void) {
+  if (!torchlean_cuda_textable_class) {
+    torchlean_cuda_textable_class = lean_register_external_class(torchlean_cuda_textable_finalize,
+                                                                torchlean_cuda_textable_foreach);
+  }
+  return torchlean_cuda_textable_class;
+}
+
+extern "C" torchlean_cuda_textable* torchlean_cuda_textable_unbox(b_lean_obj_arg obj) {
+  lean_object* o = (lean_object*)obj;
+  if (!lean_is_external(o)) {
+    lean_internal_panic("torchlean_cuda_textable: expected external object");
+  }
+  return (torchlean_cuda_textable*)lean_get_external_data(o);
+}
+
+extern "C" lean_obj_res torchlean_cuda_textable_box(torchlean_cuda_textable* t) {
+  return lean_alloc_external(torchlean_cuda_textable_get_class(), t);
+}
+
+// --- Construction ------------------------------------------------------------
+
+extern "C" LEAN_EXPORT lean_obj_res torchlean_cuda_textable_make(b_lean_obj_arg data,
+                                                                b_lean_obj_arg width,
+                                                                b_lean_obj_arg layers,
+                                                                uint8_t hw_filter) {
+  const uint32_t w = nat_to_u32_or_panic(width, "torchlean_cuda_textable_make: width out of range");
+  const uint32_t l = nat_to_u32_or_panic(layers, "torchlean_cuda_textable_make: layers out of range");
+  if (w == 0 || l == 0) {
+    lean_internal_panic("torchlean_cuda_textable_make: width and layers must be >= 1");
+  }
+  lean_object* A = (lean_object*)data;
+  const size_t n = lean_sarray_size(A);
+  if (n != (size_t)w * (size_t)l) {
+    lean_internal_panic("torchlean_cuda_textable_make: data size must equal layers * width");
+  }
+  const double* src = lean_float_array_cptr(A);
+
+  torchlean_cuda_textable* t =
+      (torchlean_cuda_textable*)malloc(sizeof(torchlean_cuda_textable));
+  if (!t) {
+    lean_internal_panic_out_of_memory();
+  }
+  t->width = w;
+  t->layers = l;
+  t->filter_mode = hw_filter ? 1u : 0u;
+  t->cuarray = NULL;
+  t->tex = 0;
+  t->host = (float*)malloc(n * sizeof(float));
+  if (!t->host) {
+    free(t);
+    lean_internal_panic_out_of_memory();
+  }
+  for (size_t i = 0; i < n; ++i) {
+    t->host[i] = (float)src[i];
+  }
+
+  cudaChannelFormatDesc desc = cudaCreateChannelDesc<float>();
+  cudaArray_t arr = NULL;
+  checkCuda(cudaMalloc3DArray(&arr, &desc, make_cudaExtent(w, 0, l), cudaArrayLayered),
+            "torchlean_cuda_textable_make: cudaMalloc3DArray failed");
+  t->cuarray = (void*)arr;
+
+  cudaMemcpy3DParms copy;
+  memset(&copy, 0, sizeof(copy));
+  copy.srcPtr = make_cudaPitchedPtr((void*)t->host, (size_t)w * sizeof(float), (size_t)w, 1);
+  copy.dstArray = arr;
+  copy.extent = make_cudaExtent(w, 1, l);
+  copy.kind = cudaMemcpyHostToDevice;
+  checkCuda(cudaMemcpy3D(&copy), "torchlean_cuda_textable_make: cudaMemcpy3D failed");
+
+  cudaResourceDesc res;
+  memset(&res, 0, sizeof(res));
+  res.resType = cudaResourceTypeArray;
+  res.res.array.array = arr;
+
+  cudaTextureDesc texd;
+  memset(&texd, 0, sizeof(texd));
+  texd.addressMode[0] = cudaAddressModeClamp;
+  texd.addressMode[1] = cudaAddressModeClamp;
+  texd.filterMode = hw_filter ? cudaFilterModeLinear : cudaFilterModePoint;
+  texd.readMode = cudaReadModeElementType;
+  texd.normalizedCoords = 0;
+
+  cudaTextureObject_t tex = 0;
+  checkCuda(cudaCreateTextureObject(&tex, &res, &texd, NULL),
+            "torchlean_cuda_textable_make: cudaCreateTextureObject failed");
+  t->tex = (unsigned long long)tex;
+
+  return torchlean_cuda_textable_box(t);
+}
+
+// --- Fetch -------------------------------------------------------------------
+
+static constexpr int kTextableBlockSize = 256;
+
+static inline dim3 textable_blocks_for(size_t n) {
+  size_t blocks = (n + (size_t)kTextableBlockSize - 1) / (size_t)kTextableBlockSize;
+  if (blocks == 0) {
+    blocks = 1;
+  }
+  if (blocks > 2147483647ULL) {
+    blocks = 2147483647ULL;
+  }
+  return dim3((unsigned int)blocks);
+}
+
+// One kernel for both filter modes; `hw` is a launch parameter, so the branch is warp-uniform.
+// Point mode blocks FMA contraction with `__f*_rn` intrinsics: this translation unit is compiled
+// with plain `-O2` (no `--fmad=false`), and the explicit lerp must stay bit-identical to the CPU
+// stub's float32 arithmetic.
+__global__ void torchlean_textable_fetch_f32(cudaTextureObject_t tex, const float* u,
+                                             const float* layer, float* out, size_t n,
+                                             uint32_t hw, float wmax) {
+  size_t i = (size_t)blockIdx.x * (size_t)blockDim.x + (size_t)threadIdx.x;
+  if (i >= n) {
+    return;
+  }
+  float uc = fminf(fmaxf(u[i], 0.0f), wmax);
+  int L = (int)(layer[i] + 0.5f);
+  if (hw) {
+    out[i] = tex1DLayered<float>(tex, uc + 0.5f, L);
+  } else {
+    float j = floorf(uc);
+    float f = __fsub_rn(uc, j);
+    float a = tex1DLayered<float>(tex, j + 0.5f, L);
+    float b = tex1DLayered<float>(tex, fminf(j + 1.0f, wmax) + 0.5f, L);
+    out[i] = __fadd_rn(a, __fmul_rn(f, __fsub_rn(b, a)));
+  }
+}
+
+extern "C" LEAN_EXPORT lean_obj_res torchlean_cuda_textable_fetch(b_lean_obj_arg tbl,
+                                                                 b_lean_obj_arg coords,
+                                                                 b_lean_obj_arg layer_idx) {
+  torchlean_cuda_textable* t = torchlean_cuda_textable_unbox(tbl);
+  torchlean_cuda_buffer* u = torchlean_cuda_buffer_unbox(coords);
+  torchlean_cuda_buffer* l = torchlean_cuda_buffer_unbox(layer_idx);
+  torchlean_cuda_require_same_size2(u, l, "torchlean_cuda_textable_fetch");
+
+  const size_t n = u->size;
+  torchlean_cuda_buffer* out = torchlean_cuda_buffer_alloc(n);
+  if (n == 0) {
+    return torchlean_cuda_buffer_box(out);
+  }
+
+  dim3 blocks = textable_blocks_for(n);
+  dim3 threads = dim3(kTextableBlockSize);
+  torchlean_textable_fetch_f32<<<blocks, threads>>>((cudaTextureObject_t)t->tex, u->data, l->data,
+                                                    out->data, n, t->filter_mode,
+                                                    (float)(t->width - 1));
+  checkCuda(cudaGetLastError(), "cuda textable_fetch kernel launch failed");
+  return torchlean_cuda_buffer_box(out);
+}
+
+// --- Metadata ----------------------------------------------------------------
+
+extern "C" LEAN_EXPORT lean_obj_res torchlean_cuda_textable_width(b_lean_obj_arg tbl) {
+  return lean_usize_to_nat(torchlean_cuda_textable_unbox(tbl)->width);
+}
+
+extern "C" LEAN_EXPORT lean_obj_res torchlean_cuda_textable_layers(b_lean_obj_arg tbl) {
+  return lean_usize_to_nat(torchlean_cuda_textable_unbox(tbl)->layers);
+}
+
+extern "C" LEAN_EXPORT uint8_t torchlean_cuda_textable_filter_hw(b_lean_obj_arg tbl) {
+  return torchlean_cuda_textable_unbox(tbl)->filter_mode ? 1 : 0;
+}

--- a/csrc/cuda/textures/torchlean_cuda_textable_stub.c
+++ b/csrc/cuda/textures/torchlean_cuda_textable_stub.c
@@ -1,0 +1,156 @@
+// Portable CPU twin of `torchlean_cuda_textable.cu`.
+//
+// Linked by the default (non-CUDA) build. Every exported symbol matches the CUDA translation unit.
+// Point mode (`filter_mode == 0`) is bit-identical to the CUDA kernel: both sides evaluate the
+// same clamp/floor/lerp in float32 with contraction blocked (the CUDA side uses `__f*_rn`
+// intrinsics; this side uses single-assignment `float` temporaries, which baseline x86-64
+// `cc -O2` compiles without FMA contraction). Hardware mode (`filter_mode == 1`) emulates the
+// 9-bit fixed-point lerp weight (8 fractional bits, round-to-nearest); CUDA does not specify the
+// hardware's coefficient rounding, so hardware mode is compared by tolerance in both builds.
+
+#include <lean/lean.h>
+
+#include "torchlean_cuda_buffer.h"
+#include "torchlean_cuda_textable.h"
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+// --- External object plumbing ------------------------------------------------
+
+static void torchlean_cuda_textable_finalize(void* ptr) {
+  torchlean_cuda_textable* t = (torchlean_cuda_textable*)ptr;
+  if (!t) {
+    return;
+  }
+  free(t->host);
+  free(t);
+}
+
+// `torchlean_cuda_textable` holds no Lean references.
+static void torchlean_cuda_textable_foreach(void* _ptr, b_lean_obj_arg _fn) {
+  (void)_ptr;
+  (void)_fn;
+}
+
+static lean_external_class* torchlean_cuda_textable_class = NULL;
+
+static lean_external_class* torchlean_cuda_textable_get_class(void) {
+  if (!torchlean_cuda_textable_class) {
+    torchlean_cuda_textable_class = lean_register_external_class(torchlean_cuda_textable_finalize,
+                                                                torchlean_cuda_textable_foreach);
+  }
+  return torchlean_cuda_textable_class;
+}
+
+torchlean_cuda_textable* torchlean_cuda_textable_unbox(b_lean_obj_arg obj) {
+  lean_object* o = (lean_object*)obj;
+  if (!lean_is_external(o)) {
+    lean_internal_panic("torchlean_cuda_textable_stub: expected external object");
+  }
+  return (torchlean_cuda_textable*)lean_get_external_data(o);
+}
+
+lean_obj_res torchlean_cuda_textable_box(torchlean_cuda_textable* t) {
+  return lean_alloc_external(torchlean_cuda_textable_get_class(), t);
+}
+
+// --- Construction ------------------------------------------------------------
+
+LEAN_EXPORT lean_obj_res torchlean_cuda_textable_make(b_lean_obj_arg data, b_lean_obj_arg width,
+                                                      b_lean_obj_arg layers, uint8_t hw_filter) {
+  const uint32_t w = nat_to_u32_or_panic(width, "torchlean_cuda_textable_make: width out of range");
+  const uint32_t l = nat_to_u32_or_panic(layers, "torchlean_cuda_textable_make: layers out of range");
+  if (w == 0 || l == 0) {
+    lean_internal_panic("torchlean_cuda_textable_make: width and layers must be >= 1");
+  }
+  lean_object* A = (lean_object*)data;
+  const size_t n = lean_sarray_size(A);
+  if (n != (size_t)w * (size_t)l) {
+    lean_internal_panic("torchlean_cuda_textable_make: data size must equal layers * width");
+  }
+  const double* src = lean_float_array_cptr(A);
+
+  torchlean_cuda_textable* t =
+      (torchlean_cuda_textable*)malloc(sizeof(torchlean_cuda_textable));
+  if (!t) {
+    lean_internal_panic_out_of_memory();
+  }
+  t->width = w;
+  t->layers = l;
+  t->filter_mode = hw_filter ? 1u : 0u;
+  t->cuarray = NULL;
+  t->tex = 0;
+  t->host = (float*)malloc(n * sizeof(float));
+  if (!t->host) {
+    free(t);
+    lean_internal_panic_out_of_memory();
+  }
+  for (size_t i = 0; i < n; ++i) {
+    t->host[i] = (float)src[i];
+  }
+  return torchlean_cuda_textable_box(t);
+}
+
+// --- Fetch -------------------------------------------------------------------
+
+LEAN_EXPORT lean_obj_res torchlean_cuda_textable_fetch(b_lean_obj_arg tbl, b_lean_obj_arg coords,
+                                                       b_lean_obj_arg layer_idx) {
+  torchlean_cuda_textable* t = torchlean_cuda_textable_unbox(tbl);
+  torchlean_cuda_buffer* u = torchlean_cuda_buffer_unbox(coords);
+  torchlean_cuda_buffer* l = torchlean_cuda_buffer_unbox(layer_idx);
+  torchlean_cuda_require_same_size2(u, l, "torchlean_cuda_textable_fetch");
+
+  const size_t n = u->size;
+  torchlean_cuda_buffer* out = torchlean_cuda_buffer_alloc(n);
+  const float wmax = (float)(t->width - 1);
+  const long lmax = (long)t->layers - 1;
+
+  for (size_t i = 0; i < n; ++i) {
+    float uc = u->data[i];
+    if (uc < 0.0f) {
+      uc = 0.0f;
+    }
+    if (uc > wmax) {
+      uc = wmax;
+    }
+    long L = (long)(l->data[i] + 0.5f);
+    if (L < 0) {
+      L = 0;
+    }
+    if (L > lmax) {
+      L = lmax;
+    }
+    const float j = floorf(uc);
+    float f = uc - j;
+    if (t->filter_mode) {
+      // 9-bit fixed-point lerp weight: 8 fractional bits, round-to-nearest.
+      f = floorf(f * 256.0f + 0.5f) / 256.0f;
+    }
+    const float* row = t->host + (size_t)L * t->width;
+    const size_t j0 = (size_t)j;
+    const size_t j1 = (j0 + 1 < t->width) ? j0 + 1 : t->width - 1;
+    const float a = row[j0];
+    const float b = row[j1];
+    const float d = b - a;
+    const float fd = f * d;
+    out->data[i] = a + fd;
+  }
+  return torchlean_cuda_buffer_box(out);
+}
+
+// --- Metadata ----------------------------------------------------------------
+
+LEAN_EXPORT lean_obj_res torchlean_cuda_textable_width(b_lean_obj_arg tbl) {
+  return lean_usize_to_nat(torchlean_cuda_textable_unbox(tbl)->width);
+}
+
+LEAN_EXPORT lean_obj_res torchlean_cuda_textable_layers(b_lean_obj_arg tbl) {
+  return lean_usize_to_nat(torchlean_cuda_textable_unbox(tbl)->layers);
+}
+
+LEAN_EXPORT uint8_t torchlean_cuda_textable_filter_hw(b_lean_obj_arg tbl) {
+  return torchlean_cuda_textable_unbox(tbl)->filter_mode ? 1 : 0;
+}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -276,6 +276,15 @@ extern_lib torchlean_cuda_tensor (pkg) :=
     stubSrc := "csrc/cuda/tensor/torchlean_cuda_tensor_stub.c"
   }
 
+/-- Native backend for `torchlean_cuda_textable`: texture-object lookup tables when `-K cuda=true`,
+else C stub. -/
+extern_lib torchlean_cuda_textable (pkg) :=
+  buildNativeBackendLib pkg {
+    stem := "torchlean_cuda_textable"
+    cudaSrc := "csrc/cuda/textures/torchlean_cuda_textable.cu"
+    stubSrc := "csrc/cuda/textures/torchlean_cuda_textable_stub.c"
+  }
+
 -- Unified verification CLI registry: `lake exe verify -- <tool> [args...]`
 lean_exe verify where
   root := `NN.Verification.Main


### PR DESCRIPTION
`TexTable.ofFloatArray data width layers hwFilter` builds an immutable layered 1-D float32 table; `TexTable.fetch tbl coords layerIdx` evaluates piecewise-linear interpolation at grid-space coordinates `u ∈ [0, width−1]` (clamp addressing; the `+0.5` texel-center offset is handled internally) in **one launch** over the existing `Buffer` marshaling path. On the CUDA build the table is a layered `cudaArray` bound once to a `cudaTextureObject_t`; the default build ships a host-memory parity stub, so `lake build` stays green without a GPU.

Two filter modes, fixed at construction:

- **point** (default): two point fetches + an explicit contraction-blocked (`__fadd_rn`/`__fmul_rn`/`__fsub_rn`) float32 lerp — **bit-identical** between the CUDA kernel and the CPU stub. (The native backend compiles without `--fmad=false`, so FMA is blocked by intrinsics, not flags.)
- **hardware**: a single `tex1DLayered` filtered fetch — zero-ALU lerp using the texture unit's 9-bit fixed-point weight, tolerance-validated (CUDA does not specify coefficient rounding); the stub emulates the quantized weight.

### Motivation

Small tabulated transfer functions — calibration curves, inverted sensor-response tables, activation LUTs — are read-only, reused across many launches, and small enough to stay texture-cache resident. Binding one as a texture object turns a gather that would otherwise be a multi-launch composed pipeline into a single fetch per element. The op is forward-only by design (no autograd node); the lerp-slope backward is well-defined future work.

### Tests

`NN/Tests/Runtime/Cuda/TexTable.lean` (wired into the CUDA coverage suite): point mode bit-exact vs the executable `texLerpSpec` reference — compared by `Float.toBits`, not a tolerance; hardware mode within the 9-bit-weight bound of the unquantized reference; integer-node texel-center probes exact in both modes (catches ±0.5 coordinate errors); clamp-below/above, `width = 1`, multi-layer, and empty-coords edges. Like the rest of the suite it runs on the CPU stub (`lake build`) and on the GPU (`-K cuda`) alike.

### Verification

- `nvcc` compiles the kernel TU; `cc` compiles the stub; the `@[extern]` bindings elaborate; both TUs export the same symbol set so the default build links.
- `nn_tests_suite` is green on the CPU stub and with `-K cuda=true` on an RTX A4500; the point-mode stub↔GPU bit-identity holds on real texture hardware, and the texel-center probes pass under both filter modes.