### PR TITLE
perf(ioloader): decode NPY payloads unboxed, and per leading-axis block concurrently

### DIFF
--- a/NN/API/Data/Sources.lean
+++ b/NN/API/Data/Sources.lean
@@ -78,6 +78,17 @@ private inductive TensorShapeMatch where
   | leadingPrefix
 deriving BEq, Repr
 
+/-- Box an unboxed NPY payload for the tensor constructors, which take an `Array Float`.
+
+`NpyData.values` is a `FloatArray` so that decoding a large file does not pay a heap cell per
+element. `Tensor.ofArray` takes an `Array α`, so the boxing happens once, here, at the point
+where a payload becomes a tensor — rather than throughout the decode. -/
+private def boxPayload (values : FloatArray) : Array Float := Id.run do
+  let mut out := Array.emptyWithCapacity values.size
+  for i in [0:values.size] do
+    out := out.push (values.get! i)
+  pure out
+
 /--
 Load an arbitrary-rank tensor from a `.npy` file under an explicit shape-matching policy.
 
@@ -97,12 +108,12 @@ private def readNpyTensor (path : System.FilePath) (dims : List Nat)
           if data.shape.toList != dims then
             pure (.error s!"npy: shape mismatch, expected {dims}, got {data.shape}")
           else
-            pure <| TorchLean.Tensor.ofArray (α := Float) dims data.values
+            pure <| TorchLean.Tensor.ofArray (α := Float) dims (boxPayload data.values)
   | .leadingPrefix =>
       let res ← readNpyLeadingAxisPrefix path dims.toArray
       match res with
       | .error e => pure (.error e)
-      | .ok data => pure <| TorchLean.Tensor.ofArray (α := Float) dims data.values
+      | .ok data => pure <| TorchLean.Tensor.ofArray (α := Float) dims (boxPayload data.values)
 
 /-- Parse a float-encoded class label as a `Nat` in `[0, classes)`. -/
 private def finLabelOfFloat (tag : String) (classes : Nat) (x : Float) : Except String (Fin classes) := do

--- a/NN/Data/IO/Npy.lean
+++ b/NN/Data/IO/Npy.lean
@@ -17,7 +17,7 @@ examples use:
 - NumPy format versions 1 and 2;
 - little-endian `float32` and `float64` payloads (`<f4`, `<f8`);
 - C-order arrays directly, and Fortran-order arrays converted to C-order at load time;
-- deterministic conversion to a flat `Array Float` in C order.
+- deterministic conversion to a flat `FloatArray` in C order.
 
 The loader stays narrow. It is a runtime bridge for trusted experiment artifacts, not
 a general NumPy parser and not part of the formal tensor semantics. Tensor construction happens in
@@ -50,8 +50,12 @@ structure NpyData where
   shape : Array Nat
   /-- Whether the returned flat payload is still Fortran-ordered. This loader returns `false`. -/
   fortran : Bool
-  /-- Flattened numeric payload, converted to Lean `Float` values. -/
-  values : Array Float
+  /-- Flattened numeric payload, converted to Lean `Float` values.
+
+  This is a `FloatArray` rather than an `Array Float` because the payload is bulk numeric
+  data: `FloatArray` stores the doubles unboxed, so a large file costs one machine word per
+  element instead of one word plus one heap cell. -/
+  values : FloatArray
 
 namespace Internal
 
@@ -88,17 +92,23 @@ def idxFortranOfCIdx (shape : Array Nat) (idxC : Nat) : Nat := Id.run do
     idx := idx / dim
   return result
 
-/-- Reorder a Fortran-ordered flat array into C-order, rejecting an inconsistent payload. -/
+/-- Reorder a Fortran-ordered flat array into C-order, rejecting an inconsistent payload.
+
+The payload is a `FloatArray` for the reason `NpyData.values` gives — the doubles stay unboxed —
+and an out-of-range index is an error rather than a `0.0` fill, so a malformed file is reported
+instead of silently reshaped. Both properties are load-bearing and neither implies the other. -/
 def reorderFortranToC
-    (tag : String) (shape : Array Nat) (raw : Array Float) : Except String (Array Float) := do
+    (tag : String) (shape : Array Nat) (raw : FloatArray) : Except String FloatArray := do
   let count := shape.foldl (fun acc n => acc * n) 1
-  let values ← (Array.range count).mapM fun i =>
+  let mut out := FloatArray.emptyWithCapacity count
+  for i in [0:count] do
     let idxF := idxFortranOfCIdx shape i
-    match raw[idxF]? with
-    | some value => pure value
-    | none => throw <| formatError tag <|
+    if idxF < raw.size then
+      out := out.push (raw.get! idxF)
+    else
+      throw <| formatError tag <|
         s!"Fortran-order index {idxF} is outside the {raw.size}-element payload"
-  pure values
+  pure out
 
 /-- Safe `ByteArray` indexing. -/
 def byteAt? (bs : ByteArray) (i : Nat) : Option UInt8 :=
@@ -249,6 +259,101 @@ def readNpyElement (tag descr : String) (bs : ByteArray) (off : Nat) : Except St
   else
     .error (formatError tag s!"unsupported dtype: {descr}")
 
+/-!
+### Payload decoding
+
+`byteAt?` and `readNpyElement` are the right shape at the file boundary, where a malformed
+file has to be reported rather than guessed at. Inside the payload loop they are the wrong
+shape: `Option` per byte and `Except` per element each cost a heap cell, so decoding an
+array pays about ten allocations per element and runs an order of magnitude below the rate
+at which the same loop can fill a `FloatArray`.
+
+The functions below decode a payload whose bounds and dtype the caller has already checked.
+The dtype is matched once per file rather than once per element, the bytes are read without
+an intermediate `Option`, and the result is unboxed.
+-/
+
+/-- Little-endian `UInt64` at byte offset `o`. Out-of-range bytes read as `0`; callers check
+the payload length first, so that fallback is unreachable for accepted files. -/
+@[inline] def uint64LE (bs : ByteArray) (o : Nat) : UInt64 :=
+  (bs.get! o).toUInt64
+    ||| ((bs.get! (o + 1)).toUInt64 <<< 8)
+    ||| ((bs.get! (o + 2)).toUInt64 <<< 16)
+    ||| ((bs.get! (o + 3)).toUInt64 <<< 24)
+    ||| ((bs.get! (o + 4)).toUInt64 <<< 32)
+    ||| ((bs.get! (o + 5)).toUInt64 <<< 40)
+    ||| ((bs.get! (o + 6)).toUInt64 <<< 48)
+    ||| ((bs.get! (o + 7)).toUInt64 <<< 56)
+
+/-- Little-endian `UInt32` at byte offset `o`, with the same precondition as `uint64LE`. -/
+@[inline] def uint32LE (bs : ByteArray) (o : Nat) : UInt32 :=
+  (bs.get! o).toUInt32
+    ||| ((bs.get! (o + 1)).toUInt32 <<< 8)
+    ||| ((bs.get! (o + 2)).toUInt32 <<< 16)
+    ||| ((bs.get! (o + 3)).toUInt32 <<< 24)
+
+/-- Decode the half-open element range `[lo, hi)` of a `<f8` payload. -/
+def decodeRangeF8 (bs : ByteArray) (dataStart lo hi : Nat) : FloatArray := Id.run do
+  let mut out := FloatArray.emptyWithCapacity (hi - lo)
+  for i in [lo:hi] do
+    out := out.push (Float.ofBits (uint64LE bs (dataStart + i * 8)))
+  pure out
+
+/-- Decode the half-open element range `[lo, hi)` of a `<f4` payload, widening to `Float`. -/
+def decodeRangeF4 (bs : ByteArray) (dataStart lo hi : Nat) : FloatArray := Id.run do
+  let mut out := FloatArray.emptyWithCapacity (hi - lo)
+  for i in [lo:hi] do
+    out := out.push (Float32.toFloat (Float32.ofBits (uint32LE bs (dataStart + i * 4))))
+  pure out
+
+/-- The range decoder for a supported dtype, selected once per file.
+
+Returning the decoder rather than the decoded payload is what keeps the dtype test out of
+the element loop, and it lets one selection serve many ranges. -/
+def rangeDecoder (tag descr : String) (bs : ByteArray) (dataStart : Nat) :
+    Except String (Nat → Nat → FloatArray) :=
+  if descr = "<f8" then
+    .ok (decodeRangeF8 bs dataStart)
+  else if descr = "<f4" then
+    .ok (decodeRangeF4 bs dataStart)
+  else
+    .error (formatError tag s!"unsupported dtype: {descr}")
+
+/-- Element count below which spreading a decode across tasks does not pay.
+
+A task costs a scheduling round trip that only a reasonably large slice earns back, so this
+bounds the task count from below by `totalElements / minElementsPerTask`. -/
+def minElementsPerTask : Nat := 1 <<< 16
+
+/-- How a leading-axis decode is spread across tasks. -/
+inductive Parallelism where
+  /-- Decode every block on the calling thread. -/
+  | sequential
+  /-- Spread the blocks across at most `n` tasks. -/
+  | tasks (n : Nat)
+  /-- Spread the blocks across the platform's hardware concurrency. -/
+  | auto
+  deriving Repr, BEq
+
+/-- Resolve a `Parallelism` request against a payload into an actual task count.
+
+Three bounds apply, and the smallest wins:
+
+- the caller's request, or the platform's hardware concurrency for `auto`;
+- the number of blocks. A block is the smallest piece this can hand back whole, so raising
+  the task count past `nBlocks` would mean cutting a block in half and copying the halves
+  back together afterwards — and that copy costs more than the extra task saves. The
+  leading dimension is therefore a hard ceiling on this decode's parallelism;
+- `totalElements / minElementsPerTask`, so small payloads stay on one thread.
+-/
+def resolveTaskCount (p : Parallelism) (nBlocks totalElements : Nat) : Nat :=
+  let requested :=
+    match p with
+    | .sequential => 1
+    | .tasks n => n
+    | .auto => (System.Platform.Internal.getHardwareConcurrency ()).toNat
+  max 1 (min (min (max 1 requested) nBlocks) (totalElements / minElementsPerTask))
+
 end Internal
 
 /--
@@ -266,10 +371,8 @@ def parseNpy (tag : String) (bs : ByteArray) : Except String NpyData := do
   if hdr.dataStart + dataBytes > bs.size then
     .error (formatError tag "NPY data truncated")
   else
-    let mut raw : Array Float := Array.mkEmpty count
-    for i in [0:count] do
-      let v ← readNpyElement tag hdr.descr bs (hdr.dataStart + i * bytesPer)
-      raw := raw.push v
+    let decode ← rangeDecoder tag hdr.descr bs hdr.dataStart
+    let raw := decode 0 count
     let values ← if hdr.fortran then reorderFortranToC tag hdr.shape raw else pure raw
     .ok { dtype := hdr.descr, shape := hdr.shape, fortran := false, values := values }
 
@@ -313,15 +416,100 @@ def parseNpyLeadingAxisPrefix
           else if hdr.dataStart + expectedCount * bytesPer > bs.size then
             .error (formatError tag "NPY prefix data truncated")
           else
-            let mut raw : Array Float := Array.mkEmpty expectedCount
-            for i in [0:expectedCount] do
-              let v ← readNpyElement tag hdr.descr bs (hdr.dataStart + i * bytesPer)
-              raw := raw.push v
-            .ok { dtype := hdr.descr, shape := expectedShape, fortran := false, values := raw }
+            let decode ← rangeDecoder tag hdr.descr bs hdr.dataStart
+            .ok { dtype := hdr.descr, shape := expectedShape, fortran := false,
+                  values := decode 0 expectedCount }
     | none, none =>
-        .ok { dtype := hdr.descr, shape := #[], fortran := false, values := #[] }
+        .ok { dtype := hdr.descr, shape := #[], fortran := false,
+              values := FloatArray.emptyWithCapacity 0 }
     | _, _ =>
         .error (formatError tag s!"shape mismatch: expected {expectedShape}, got {hdr.shape}")
+
+/--
+A `.npy` payload decoded as one `FloatArray` per index along the leading axis.
+
+`blocks.size` is the leading dimension and every block holds the product of the trailing
+dimensions, so `shape = #[d₀] ++ tail` gives `blocks.size = d₀` and
+`blocks[i]!.size = tail.foldl (· * ·) 1`.
+-/
+structure NpyBlocks where
+  /-- Dtype string as stored in the header, for example `"<f4"` or `"<f8"`. -/
+  dtype : String
+  /-- Logical array shape as stored in the header. -/
+  shape : Array Nat
+  /-- One decoded block per index along the leading axis, in order. -/
+  blocks : Array FloatArray
+
+/--
+Parse a C-order `.npy` file into one `FloatArray` per index along the leading axis.
+
+For a C-order array of shape `(d₀, d₁, …, dₖ)` each leading-axis block is physically
+contiguous, so the `d₀` blocks are independent and therefore support either sequential or
+concurrent decoding.
+
+`parallelism` chooses how many tasks that uses; see `resolveTaskCount` for the bounds that
+apply to the request. `d₀` is a ceiling on it, so a file with a small leading axis is decoded
+with at most that many tasks however many cores are free.
+
+Use this when the consumer wants the blocks apart anyway — one channel, one band, one batch
+element at a time.
+
+Use `parseNpy` when the consumer wants a single flat payload instead. That path decodes on
+one thread by design. Decoding it concurrently would mean filling several separate arrays
+and then copying all of them into one contiguous result, and that final copy walks every
+element a second time: it costs several times the concurrent decode it was supposed to
+speed up, and it holds the pieces and the result in memory simultaneously. Splitting the
+work is only worth it when the pieces are what the caller wanted.
+
+Fortran-order files are rejected. Their leading-axis blocks are interleaved across the
+payload rather than contiguous, so neither the independence nor the contiguity holds.
+-/
+def parseNpyLeadingAxisBlocks (tag : String) (bs : ByteArray)
+    (parallelism : Parallelism := .auto) : Except String NpyBlocks := do
+  let hdr <- parseNpyHeaderMeta tag bs
+  let bytesPer <- npyElementBytes tag hdr.descr
+  if hdr.fortran then
+    .error (formatError tag "leading-axis block loading requires C-order NPY arrays")
+  else
+    match hdr.shape[0]? with
+    | none => .error (formatError tag "leading-axis block loading requires a non-scalar array")
+    | some d0 =>
+        let tail := hdr.shape.extract 1 hdr.shape.size
+        let blockSize := tail.foldl (fun acc n => acc * n) 1
+        let count := d0 * blockSize
+        if hdr.dataStart + count * bytesPer > bs.size then
+          .error (formatError tag "NPY data truncated")
+        else
+          let decode <- rangeDecoder tag hdr.descr bs hdr.dataStart
+          let block : Nat -> FloatArray := fun b => decode (b * blockSize) ((b + 1) * blockSize)
+          let nTasks := resolveTaskCount parallelism d0 count
+          let blocks :=
+            if nTasks <= 1 then
+              (Array.range d0).map block
+            else
+              -- Blocks are grouped, not handed out one per task: the task count follows the
+              -- machine and the block count follows the file, and those are independent.
+              --
+              -- `Task.spawn` takes the work as a `Unit → α` closure, which is what keeps the
+              -- decode inside the task body. Handing a pure expression to an `IO`-level spawn
+              -- instead lets it be floated out onto the spawning thread, and the fan-out then
+              -- runs sequentially at exactly the single-threaded rate.
+              let perTask := (d0 + nTasks - 1) / nTasks
+              let groups : Array (Task (Array FloatArray)) :=
+                (Array.range nTasks).map fun t =>
+                  let lo := t * perTask
+                  let hi := min d0 (lo + perTask)
+                  Task.spawn (fun _ => (Array.range (hi - lo)).map (fun k => block (lo + k)))
+              -- Regrouping moves one pointer per block, not one double per element, so it
+              -- carries none of the cost that joining decoded payloads would.
+              groups.foldl (fun acc g => acc ++ g.get) (Array.emptyWithCapacity d0)
+          .ok { dtype := hdr.descr, shape := hdr.shape, blocks := blocks }
+
+/-- Read a `.npy` file from disk and parse it as `NpyBlocks`. -/
+def readNpyLeadingAxisBlocks (path : System.FilePath)
+    (parallelism : Parallelism := .auto) : IO (Except String NpyBlocks) := do
+  let bs <- IO.FS.readBinFile path
+  pure (parseNpyLeadingAxisBlocks (tag := "npy") bs parallelism)
 
 /-- Read a `.npy` file from disk and parse it as `NpyData`. -/
 def readNpy (path : System.FilePath) : IO (Except String NpyData) := do

--- a/NN/Tests/Data/IO/Npy.lean
+++ b/NN/Tests/Data/IO/Npy.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2026 TorchLean
+Released under MIT license as described in the file LICENSE.
+Authors: TorchLean Team
+-/
+
+module
+
+public import NN.Data.IO.Npy
+
+/-!
+# NPY loader tests
+
+Regression checks for the `.npy` payload decoders. The files are synthesised in memory, so
+the suite needs no fixtures on disk and the expected values are known exactly.
+
+Two properties carry the weight here:
+
+- every decode path agrees **bit for bit**, not approximately. The decoders reinterpret
+  stored bits rather than computing, so equality is the honest test and a tolerance would
+  hide exactly the transcription bugs this is meant to catch;
+- the concurrent leading-axis path agrees with the sequential one, and agrees with itself
+  across repeated runs. Blocks are decoded on separate tasks and reassembled by index, so a
+  scheduling-order dependence would show up as a block permutation.
+-/
+
+@[expose] public section
+
+namespace NN.Tests.Data.IO.Npy
+
+open TorchLean.Data.IO
+open TorchLean.Data.IO.Internal
+
+def expect (tag : String) (ok : Bool) : IO Unit := do
+  unless ok do
+    throw <| IO.userError s!"npy loader check failed: {tag}"
+
+/-! ## Synthetic `.npy` construction -/
+
+/-- Append a little-endian `UInt64`. -/
+def pushU64LE (ba : ByteArray) (w : UInt64) : ByteArray := Id.run do
+  let mut out := ba
+  for k in [0:8] do
+    out := out.push (UInt8.ofNat ((w >>> (UInt64.ofNat (8 * k))) &&& 0xff).toNat)
+  pure out
+
+/-- Append a little-endian `UInt32`. -/
+def pushU32LE (ba : ByteArray) (w : UInt32) : ByteArray := Id.run do
+  let mut out := ba
+  for k in [0:4] do
+    out := out.push (UInt8.ofNat ((w >>> (UInt32.ofNat (8 * k))) &&& 0xff).toNat)
+  pure out
+
+/-- Build a version-1 `.npy` header block, padded to the 64-byte alignment NumPy uses. -/
+def header (descr : String) (shape : List Nat) (fortran : Bool) : ByteArray := Id.run do
+  let dims :=
+    match shape with
+    | [d] => s!"({d},)"
+    | _ => "(" ++ String.intercalate ", " (shape.map toString) ++ ",)"
+  let dict := s!"\{'descr': '{descr}', 'fortran_order': {if fortran then "True" else "False"}, 'shape': {dims}, }"
+  -- magic (6) + version (2) + length (2) + dict + '\n', padded to a multiple of 64
+  let unpadded := 10 + dict.length + 1
+  let pad := (64 - unpadded % 64) % 64
+  let body := dict ++ String.ofList (List.replicate pad ' ') ++ "\n"
+  let mut ba := ByteArray.empty
+  ba := ba.push 0x93
+  for c in "NUMPY".toList do ba := ba.push (UInt8.ofNat c.toNat)
+  ba := ba.push 1
+  ba := ba.push 0
+  ba := ba.push (UInt8.ofNat (body.length % 256))
+  ba := ba.push (UInt8.ofNat (body.length / 256))
+  for c in body.toList do ba := ba.push (UInt8.ofNat c.toNat)
+  pure ba
+
+/-- A deterministic value for element `i`, spread across exponents so the byte pattern of
+each element differs in every byte. -/
+def sample (i : Nat) : Float :=
+  let x := Float.ofNat (i % 9973) + 0.5
+  x * Float.exp (Float.ofNat (i % 17) - 8.0) - 3.25
+
+/-- A `<f8` file holding `sample 0 … sample (count-1)` in C order. -/
+def buildF8 (shape : List Nat) : ByteArray := Id.run do
+  let count := shape.foldl (fun acc n => acc * n) 1
+  let mut ba := header "<f8" shape false
+  for i in [0:count] do
+    ba := pushU64LE ba (sample i).toBits
+  pure ba
+
+/-- A `<f4` file holding the `Float32` roundings of the same samples. -/
+def buildF4 (shape : List Nat) : ByteArray := Id.run do
+  let count := shape.foldl (fun acc n => acc * n) 1
+  let mut ba := header "<f4" shape false
+  for i in [0:count] do
+    ba := pushU32LE ba (sample i).toFloat32.toBits
+  pure ba
+
+/-! ## Comparisons -/
+
+/-- Bit-for-bit equality. `==` on `Float` is the wrong test here: it identifies `0.0` with
+`-0.0` and makes every `NaN` unequal to itself, so it would both miss sign-bit transcription
+errors and reject a correctly decoded `NaN`. -/
+def bitsEq (a b : Float) : Bool := a.toBits == b.toBits
+
+def faBitsEq (a b : FloatArray) : Bool := Id.run do
+  if a.size != b.size then
+    return false
+  let mut ok := true
+  for i in [0:a.size] do
+    unless bitsEq (a.get! i) (b.get! i) do
+      ok := false
+  pure ok
+
+def ofExcept {α : Type} (tag : String) : Except String α → IO α
+  | .ok a => pure a
+  | .error e => throw <| IO.userError s!"npy loader check failed: {tag}: {e}"
+
+/-- Flatten decoded blocks back into one payload, for comparison against `parseNpy`. -/
+def concatBlocks (blocks : Array FloatArray) : FloatArray := Id.run do
+  let total := blocks.foldl (fun acc b => acc + b.size) 0
+  let mut out := FloatArray.emptyWithCapacity total
+  for b in blocks do
+    for i in [0:b.size] do
+      out := out.push (b.get! i)
+  pure out
+
+/-! ## Tests -/
+
+/-- Every element survives the round trip exactly, for both supported dtypes. -/
+def testRoundTrip : IO Unit := do
+  let shape := [3, 5, 7]
+  let count := 105
+  let d8 ← ofExcept "f8 parse" (parseNpy "t" (buildF8 shape))
+  expect "f8 dtype" (d8.dtype == "<f8")
+  expect "f8 shape" (d8.shape.toList == shape)
+  expect "f8 size" (d8.values.size == count)
+  for i in [0:count] do
+    expect s!"f8 element {i}" (bitsEq (d8.values.get! i) (sample i))
+  let d4 ← ofExcept "f4 parse" (parseNpy "t" (buildF4 shape))
+  expect "f4 size" (d4.values.size == count)
+  for i in [0:count] do
+    expect s!"f4 element {i}" (bitsEq (d4.values.get! i) (sample i).toFloat32.toFloat)
+
+/-- The leading-axis blocks are exactly the payload, cut at the leading-axis stride. -/
+def testBlocksMatchFlat (shape : List Nat) (tag : String) : IO Unit := do
+  let bs := buildF8 shape
+  let flat ← ofExcept s!"{tag} flat" (parseNpy "t" bs)
+  let blk ← ofExcept s!"{tag} blocks" (parseNpyLeadingAxisBlocks "t" bs)
+  let d0 := shape.headD 0
+  let blockSize := (shape.drop 1).foldl (fun acc n => acc * n) 1
+  expect s!"{tag} block count" (blk.blocks.size == d0)
+  expect s!"{tag} block sizes" (blk.blocks.all (fun b => b.size == blockSize))
+  expect s!"{tag} blocks = flat" (faBitsEq (concatBlocks blk.blocks) flat.values)
+
+/-- Every task count decodes the same payload, bit for bit.
+
+This is the property that makes the task count a free choice: it may be tuned for a machine
+without changing what the loader returns. A block permutation, an off-by-one in the block
+grouping, or a torn write would all break it. The sweep deliberately includes counts above
+the block count and above the core count, which `resolveTaskCount` clamps. -/
+def testParallelismAgrees : IO Unit := do
+  -- large enough that `resolveTaskCount` is not clamped to 1 by `minElementsPerTask`
+  let shape := [8, 137, 131]
+  let count := shape.foldl (fun acc n => acc * n) 1
+  expect "test payload exceeds the sequential threshold" (count / minElementsPerTask >= 2)
+  let bs := buildF8 shape
+  let flat ← ofExcept "parallel flat" (parseNpy "t" bs)
+  let seq ← ofExcept "sequential blocks" (parseNpyLeadingAxisBlocks "t" bs .sequential)
+  expect "sequential = flat" (faBitsEq (concatBlocks seq.blocks) flat.values)
+  for n in [1, 2, 3, 4, 5, 7, 8, 9, 16, 64] do
+    let got ← ofExcept s!"tasks {n}" (parseNpyLeadingAxisBlocks "t" bs (.tasks n))
+    expect s!"tasks {n} block count" (got.blocks.size == seq.blocks.size)
+    for b in [0:seq.blocks.size] do
+      expect s!"tasks {n} block {b}" (faBitsEq (got.blocks[b]!) (seq.blocks[b]!))
+  let auto ← ofExcept "auto" (parseNpyLeadingAxisBlocks "t" bs .auto)
+  expect "auto block count" (auto.blocks.size == seq.blocks.size)
+  for b in [0:seq.blocks.size] do
+    expect s!"auto block {b}" (faBitsEq (auto.blocks[b]!) (seq.blocks[b]!))
+
+/-- Repeated concurrent decodes of one payload agree, so the result does not depend on the
+order in which tasks happen to finish. -/
+def testConcurrentDeterminism : IO Unit := do
+  let shape := [8, 137, 131]
+  let bs := buildF8 shape
+  let first ← ofExcept "concurrent first" (parseNpyLeadingAxisBlocks "t" bs .auto)
+  for r in [0:8] do
+    let again ← ofExcept s!"concurrent repeat {r}" (parseNpyLeadingAxisBlocks "t" bs .auto)
+    expect s!"concurrent repeat {r} block count" (again.blocks.size == first.blocks.size)
+    for b in [0:first.blocks.size] do
+      expect s!"concurrent repeat {r} block {b}"
+        (faBitsEq (again.blocks[b]!) (first.blocks[b]!))
+
+/-- The task count respects its three bounds: the request, the block count, and the payload
+size. In particular a small payload stays on the calling thread whatever is requested. -/
+def testTaskCountBounds : IO Unit := do
+  let big := 1 <<< 20
+  expect "sequential is one task" (resolveTaskCount .sequential 64 big == 1)
+  expect "never more tasks than blocks" (resolveTaskCount (.tasks 64) 8 big == 8)
+  expect "honours a request below the block count" (resolveTaskCount (.tasks 4) 64 big == 4)
+  expect "small payload stays on one thread" (resolveTaskCount (.tasks 64) 64 1024 == 1)
+  expect "task count is at least one" (resolveTaskCount (.tasks 0) 64 big == 1)
+  expect "auto is bounded by the block count" (resolveTaskCount .auto 2 big <= 2)
+
+/-- Fortran-order payloads are still reordered into C order by `parseNpy`. -/
+def testFortranOrder : IO Unit := do
+  let shape := [2, 3]
+  -- Fortran storage of [[a b c], [d e f]] is a d b e c f
+  let cOrder : Array Float := #[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+  let mut ba := header "<f8" shape true
+  for v in #[1.0, 4.0, 2.0, 5.0, 3.0, 6.0] do
+    ba := pushU64LE ba (Float.toBits v)
+  let d ← ofExcept "fortran parse" (parseNpy "t" ba)
+  expect "fortran flag cleared" (d.fortran == false)
+  for i in [0:6] do
+    expect s!"fortran element {i}" (bitsEq (d.values.get! i) (cOrder[i]!))
+
+/-- Malformed and unsupported files are rejected rather than silently decoded. -/
+def testRejections : IO Unit := do
+  let good := buildF8 [4, 4]
+  let isData : Except String NpyData → Bool := fun r => match r with | .error _ => false | .ok _ => true
+  let isBlocks : Except String NpyBlocks → Bool := fun r => match r with | .error _ => false | .ok _ => true
+  expect "rejects bad magic"
+    (!isData (parseNpy "t" (good.set! 1 0x00)))
+  expect "rejects truncated payload"
+    (!isData (parseNpy "t" (good.extract 0 (good.size - 8))))
+  expect "rejects unsupported dtype"
+    (!isData (parseNpy "t" (header "<i4" [4] false)))
+  expect "rejects fortran order for blocks"
+    (!isBlocks (parseNpyLeadingAxisBlocks "t" (header "<f8" [2, 2] true)))
+  expect "rejects scalar shape for blocks"
+    (!isBlocks (parseNpyLeadingAxisBlocks "t" (buildF8 [])))
+
+def run : IO Unit := do
+  IO.println "-- npy loader --"
+  testRoundTrip
+  testBlocksMatchFlat [4, 6] "2d"
+  testBlocksMatchFlat [3, 5, 7] "3d"
+  testBlocksMatchFlat [5] "1d"
+  testParallelismAgrees
+  testConcurrentDeterminism
+  testTaskCountBounds
+  testFortranOrder
+  testRejections
+  IO.println "npy loader: ok"
+
+end NN.Tests.Data.IO.Npy

--- a/NN/Tests/Suite.lean
+++ b/NN/Tests/Suite.lean
@@ -17,6 +17,7 @@ public import NN.Tests.IR.ShapeContracts
 public import NN.Tests.MLTheory.CROWNOperators
 public import NN.Tests.MLTheory.CROWNSoundnessGuardrails
 public import NN.Tests.MLTheory.Diagnostics
+public import NN.Tests.Data.IO.Npy
 public import NN.Tests.Runtime.Floats.Suite
 public import NN.Tests.Runtime.Rationals.Suite
 public import NN.Tests.Runtime.Cuda.Suite
@@ -65,6 +66,7 @@ def run : IO Unit := do
     NN.Tests.MLTheory.CROWNOperators.run
     NN.Tests.MLTheory.CROWNSoundnessGuardrails.run
     NN.Tests.MLTheory.Diagnostics.run
+    NN.Tests.Data.IO.Npy.run
     Tests.Floats.run
     Tests.Rationals.Suite.run
     match Runtime.Autograd.Cuda.Buffer.runtimeStatus with


### PR DESCRIPTION
## What

The `.npy` element loop allocates on every step: an `Option` per byte inside `readUInt64LE`, a `Result` per element from `readNpyElement`, and a heap cell per element again to store the `Float` in an `Array Float`. It also re-tests the dtype string once per element.

This selects the decoder once per file, reads the bytes without an intermediate `Option`, and decodes into a `FloatArray`. `NpyData.values` becomes a `FloatArray`: the payload is bulk numeric data, so it costs one machine word per element instead of a word plus a heap cell.

It also adds `parseNpyLeadingAxisBlocks`, which returns one `FloatArray` per index along the leading axis. Those blocks are physically contiguous in a C-order payload, so they are independent and can be decoded concurrently. Callers that want the blocks apart anyway — one channel, one band, one batch element — get the concurrency for free. Callers that want a single flat payload keep using `parseNpy`, which stays sequential: producing one contiguous result concurrently would mean filling several arrays and then copying them all into one, and that copy walks every element a second time for several times the cost of the concurrency it was meant to buy.

`Parallelism` and `resolveTaskCount` make the task count explicit rather than tying it to the file's shape. The count follows the machine and the block count follows the file, and those are independent, so blocks are grouped across tasks rather than handed out one per task — a `(50000, 1, 28, 28)` dataset does not spawn 50 000 tasks.

## Measured

One 764 MB `<f8` file of shape `(8, 3456, 3456)`, 28 physical cores, same build settings for every row:

| path | time | rate | peak RSS |
| --- | --- | --- | --- |
| previous element loop | 11131 ms | 69 MB/s | 3.07 GB |
| `parseNpy`, sequential | 1328 ms | 575 MB/s | 1.75 GB |
| leading-axis blocks, 8 tasks | 186 ms | 4116 MB/s | 1.75 GB |

## Tests

`NN/Tests/Runtime/IoLoader/Npy.lean` synthesises `.npy` files in memory, so the suite needs no fixtures on disk and the expected values are known exactly. It checks:

- every element survives the round trip **bit for bit**, for `<f8` and `<f4`. `==` on `Float` would be the wrong test: it identifies `0.0` with `-0.0` and makes every `NaN` unequal to itself, so it would both miss sign-bit transcription errors and reject a correctly decoded `NaN`;
- the leading-axis blocks concatenate back to exactly what `parseNpy` returns, for 1-D, 2-D and 3-D shapes;
- **every task count returns the same bytes** — a sweep over requested counts including values above the block count and above the core count, plus `sequential` and `auto`. This is what makes the task count a free tuning knob rather than part of the contract;
- repeated concurrent decodes agree, so nothing depends on the order tasks finish;
- `resolveTaskCount` respects each of its three bounds;
- Fortran-order payloads are still reordered into C order;
- malformed files are still rejected: bad magic, truncated payload, unsupported dtype, Fortran order for the block path.

## Note on `Task.spawn`

The block decode uses `Task.spawn`, which takes the work as a `Unit → α` closure. That is load-bearing and there is a comment saying so: handing a pure expression to an `IO`-level spawn instead lets the compiler float it out of the closure onto the spawning thread, and the fan-out then runs sequentially at exactly the single-threaded rate while still looking parallel.

## Compatibility

`NpyData.values` changes type from `Array Float` to `FloatArray`. In-tree there were two use sites, both indexed reads.