### PR TITLE
feat(cuda): report device identity and compiled architecture

### DIFF
--- a/NN/Runtime/Autograd/Engine/Cuda/Buffer.lean
+++ b/NN/Runtime/Autograd/Engine/Cuda/Buffer.lean
@@ -194,6 +194,128 @@ def allocatorStatsWithToken (token : UInt32) : IO AllocatorStats := do
 def allocatorStats : IO AllocatorStats :=
   allocatorStatsWithToken 0
 
+/-! ### Device identity
+
+A measurement is only comparable if it names the machine it was taken on. The allocator snapshot
+answers *how much* device memory there is; these answer *which device* — the fact a benchmark row
+needs in order to be filed beside another one. -/
+
+@[never_extract, extern "torchlean_cuda_device_name"]
+opaque deviceNameRaw (u : UInt32) : String
+
+@[never_extract, extern "torchlean_cuda_compiled_arch_list"]
+opaque compiledArchListRaw (u : UInt32) : String
+
+@[never_extract, extern "torchlean_cuda_device_index"]
+opaque deviceIndexRaw (u : UInt32) : UInt32
+
+@[never_extract, extern "torchlean_cuda_device_capability"]
+opaque deviceCapabilityRaw (u : UInt32) : UInt32
+
+@[never_extract, extern "torchlean_cuda_device_sm_count"]
+opaque deviceSmCountRaw (u : UInt32) : UInt32
+
+@[never_extract, extern "torchlean_cuda_device_clock_khz"]
+opaque deviceClockKhzRaw (u : UInt32) : UInt32
+
+@[never_extract, extern "torchlean_cuda_device_mem_clock_khz"]
+opaque deviceMemClockKhzRaw (u : UInt32) : UInt32
+
+@[never_extract, extern "torchlean_cuda_device_mem_bus_width"]
+opaque deviceMemBusWidthRaw (u : UInt32) : UInt32
+
+@[never_extract, extern "torchlean_cuda_driver_version"]
+opaque driverVersionRaw (u : UInt32) : UInt32
+
+@[never_extract, extern "torchlean_cuda_runtime_version"]
+opaque runtimeVersionRaw (u : UInt32) : UInt32
+
+/--
+Identity of the CUDA device this process is using.
+
+Every field is what `cudaGetDeviceProperties` reports for the current device, except the two
+version fields, which come from `cudaDriverGetVersion` / `cudaRuntimeGetVersion`. `capability` is
+`major * 10 + minor`, so it reads the way an `-arch=sm_XY` flag is spelled — which is the
+comparison that matters, because a binary compiled for a lower architecture still runs here
+through PTX JIT and would otherwise report a device that says nothing about the code that ran on
+it.
+
+In the CPU stub, and in a CUDA build on a host with no reachable device, `name` is empty and every
+scalar is `0`. `deviceInfo` returns `none` in that case rather than a record of zeroes.
+-/
+structure DeviceInfo where
+  name : String
+  index : UInt32
+  /-- `major * 10 + minor` — `86` is `sm_86`, `120` is `sm_120`. -/
+  capability : UInt32
+  smCount : UInt32
+  clockKhz : UInt32
+  memClockKhz : UInt32
+  memBusWidthBits : UInt32
+  totalBytes : UInt64
+  /-- `cudaDriverGetVersion`, e.g. `12060` for 12.6. -/
+  driverVersion : UInt32
+  /-- `cudaRuntimeGetVersion`, e.g. `12060` for 12.6. -/
+  runtimeVersion : UInt32
+deriving Repr
+
+/-- Read the current device's identity, or `none` when there is no device to name (the CPU stub, or
+a CUDA build on a host where no card answers). -/
+def deviceInfo : IO (Option DeviceInfo) := do
+  let name := deviceNameRaw 0
+  if name.isEmpty then return none
+  return some
+    { name
+      index := deviceIndexRaw 0
+      capability := deviceCapabilityRaw 0
+      smCount := deviceSmCountRaw 0
+      clockKhz := deviceClockKhzRaw 0
+      memClockKhz := deviceMemClockKhzRaw 0
+      memBusWidthBits := deviceMemBusWidthRaw 0
+      totalBytes := allocatorDeviceTotalBytesRaw 0
+      driverVersion := driverVersionRaw 0
+      runtimeVersion := runtimeVersionRaw 0 }
+
+/-- The `sm_XY` targets this binary was compiled for, as `__CUDA_ARCH_LIST__` spells them
+(`"860"`, `"750,860"`). Empty in the CPU stub, and empty in a CUDA build whose compiler did not
+define the macro. -/
+def compiledArchList : String := compiledArchListRaw 0
+
+/-- Whether this binary holds native code for the device it is running on.
+
+`false` here does not mean broken — PTX JIT will produce code for the device from the embedded
+intermediate representation, and it will run. It means the timings are of JIT-compiled code
+generated for an architecture the compiler was never told about, which is a different measurement
+from the one a reader will assume, and the only place that difference is visible is here.
+
+An empty compiled list is not evidence either way (no device build, or no macro), so it answers
+`true` rather than warning about a build it cannot see. -/
+def DeviceInfo.runsNatively (d : DeviceInfo) : Bool :=
+  compiledArchList.isEmpty ||
+    (compiledArchList.splitOn ",").any (fun a => a.trimAscii.toString == toString (d.capability.toNat * 10))
+
+/-- A CUDA version integer (`12060`) as it is written (`12.6`). -/
+def versionString (v : UInt32) : String :=
+  let n := v.toNat
+  s!"{n / 1000}.{(n % 1000) / 10}"
+
+/-- Peak theoretical memory bandwidth in GB/s, from the memory clock and bus width — the roofline
+denominator, so that a row reporting achieved GB/s can be read as a fraction without the reader
+having to look the card up. Double data rate is assumed (every device this runs on). -/
+def DeviceInfo.peakBandwidthGBs (d : DeviceInfo) : Float :=
+  (Float.ofNat d.memClockKhz.toNat) * 1.0e3 * 2.0 *
+    (Float.ofNat d.memBusWidthBits.toNat / 8.0) / 1.0e9
+
+/-- One-line device identity for a benchmark header. -/
+def DeviceInfo.format (d : DeviceInfo) : String :=
+  s!"{d.name} (device {d.index}, sm_{d.capability}, {d.smCount} SMs, " ++
+  s!"{(Float.ofNat d.totalBytes.toNat) / (1024.0 * 1024.0 * 1024.0)} GiB, " ++
+  s!"~{d.peakBandwidthGBs} GB/s peak, " ++
+  s!"driver {versionString d.driverVersion}, runtime {versionString d.runtimeVersion})" ++
+  (if compiledArchList.isEmpty then ""
+   else if d.runsNatively then s!" [compiled for {compiledArchList}]"
+   else s!" [WARNING: compiled for {compiledArchList}, NOT sm_{d.capability} — running via PTX JIT]")
+
 /-- Format a byte count as MiB for allocator progress messages. -/
 def mibString (bytes : UInt64) : String :=
   let mib := (Float.ofNat bytes.toNat) / (1024.0 * 1024.0)

--- a/csrc/cuda/common/torchlean_cuda_buffer.h
+++ b/csrc/cuda/common/torchlean_cuda_buffer.h
@@ -131,6 +131,26 @@ LEAN_EXPORT uint64_t torchlean_cuda_wrapper_finalize_count(uint32_t u);
 LEAN_EXPORT uint64_t torchlean_cuda_allocator_device_free_bytes(uint32_t u);
 LEAN_EXPORT uint64_t torchlean_cuda_allocator_device_total_bytes(uint32_t u);
 
+// Device identity. A benchmark that cannot name the device it ran on produces a number nobody can
+// compare, so these expose what `cudaGetDeviceProperties` already knows about the current device.
+// The name is a fresh Lean string; every other field is a scalar, `0` when no device is reachable
+// and in the CPU stub. `capability` is `major * 10 + minor` (so `sm_86` reads `86`), matching the
+// `-arch=sm_XY` spelling a build is compiled for.
+LEAN_EXPORT lean_obj_res torchlean_cuda_device_name(uint32_t u);
+// The `sm_XY` targets this binary was actually compiled for, comma-separated in
+// `__CUDA_ARCH_LIST__` spelling (`"860"`, `"750,860"`), empty in the CPU stub. A binary whose list
+// omits the running device's capability reaches it through PTX JIT, which is a different thing to
+// have measured, so the pair of facts has to be reportable together.
+LEAN_EXPORT lean_obj_res torchlean_cuda_compiled_arch_list(uint32_t u);
+LEAN_EXPORT uint32_t torchlean_cuda_device_index(uint32_t u);
+LEAN_EXPORT uint32_t torchlean_cuda_device_capability(uint32_t u);
+LEAN_EXPORT uint32_t torchlean_cuda_device_sm_count(uint32_t u);
+LEAN_EXPORT uint32_t torchlean_cuda_device_clock_khz(uint32_t u);
+LEAN_EXPORT uint32_t torchlean_cuda_device_mem_clock_khz(uint32_t u);
+LEAN_EXPORT uint32_t torchlean_cuda_device_mem_bus_width(uint32_t u);
+LEAN_EXPORT uint32_t torchlean_cuda_driver_version(uint32_t u);
+LEAN_EXPORT uint32_t torchlean_cuda_runtime_version(uint32_t u);
+
 // Lean `Buffer × Buffer × Buffer` as nested pairs.
 static inline lean_object* torchlean_cuda_box_three_buffers(
     torchlean_cuda_buffer* first, torchlean_cuda_buffer* second,

--- a/csrc/cuda/tensor/torchlean_cuda_tensor.cu
+++ b/csrc/cuda/tensor/torchlean_cuda_tensor.cu
@@ -956,6 +956,118 @@ extern "C" LEAN_EXPORT uint64_t torchlean_cuda_allocator_device_total_bytes(uint
   return err == cudaSuccess ? (uint64_t)totalBytes : 0u;
 }
 
+// ---------------------------------------------------------------------------------------------
+// Device identity.
+//
+// `cudaGetDeviceProperties` is a comparatively expensive query and the answer cannot change for a
+// device index, so it is read once and cached. A failure caches the zeroed record: a host with no
+// reachable device answers "" / 0 exactly as the CPU stub does, which is what lets a caller print
+// one line either way instead of branching on the build flavour.
+static cudaDeviceProp g_torchlean_cuda_device_prop;
+static int g_torchlean_cuda_device_index = 0;
+static bool g_torchlean_cuda_device_prop_valid = false;
+static pthread_once_t g_torchlean_cuda_device_prop_once = PTHREAD_ONCE_INIT;
+
+static void torchlean_cuda_device_prop_init(void) {
+  memset(&g_torchlean_cuda_device_prop, 0, sizeof(g_torchlean_cuda_device_prop));
+  int dev = 0;
+  if (cudaGetDevice(&dev) != cudaSuccess) return;
+  if (cudaGetDeviceProperties(&g_torchlean_cuda_device_prop, dev) != cudaSuccess) return;
+  g_torchlean_cuda_device_index = dev;
+  g_torchlean_cuda_device_prop_valid = true;
+}
+
+static const cudaDeviceProp* torchlean_cuda_device_prop(void) {
+  pthread_once(&g_torchlean_cuda_device_prop_once, torchlean_cuda_device_prop_init);
+  return g_torchlean_cuda_device_prop_valid ? &g_torchlean_cuda_device_prop : nullptr;
+}
+
+// nvcc defines `__CUDA_ARCH_LIST__` in host compilation too, so the binary can state its own
+// compilation targets without the build system having to thread them through as a define.
+//
+// The stringify macros are VARIADIC, and that is the whole point rather than a stylistic choice:
+// a multi-architecture build expands `__CUDA_ARCH_LIST__` to a comma-separated list
+// (`750,860,890,900,1200`), which the preprocessor hands to the macro as five arguments, not one.
+// A single-parameter `#x` compiles fine for a one-architecture build and fails to compile for
+// every other — the exact case this reporting exists to describe. `#__VA_ARGS__` stringifies the
+// whole list, commas included, which is the format the Lean side splits on.
+#ifdef __CUDA_ARCH_LIST__
+#define TORCHLEAN_STRINGIFY_INNER(...) #__VA_ARGS__
+#define TORCHLEAN_STRINGIFY(...) TORCHLEAN_STRINGIFY_INNER(__VA_ARGS__)
+#define TORCHLEAN_CUDA_ARCH_LIST_STR TORCHLEAN_STRINGIFY(__CUDA_ARCH_LIST__)
+#else
+#define TORCHLEAN_CUDA_ARCH_LIST_STR ""
+#endif
+
+extern "C" LEAN_EXPORT lean_obj_res torchlean_cuda_compiled_arch_list(uint32_t u) {
+  (void)u;
+  return lean_mk_string(TORCHLEAN_CUDA_ARCH_LIST_STR);
+}
+
+extern "C" LEAN_EXPORT lean_obj_res torchlean_cuda_device_name(uint32_t u) {
+  (void)u;
+  const cudaDeviceProp* p = torchlean_cuda_device_prop();
+  return lean_mk_string(p ? p->name : "");
+}
+
+extern "C" LEAN_EXPORT uint32_t torchlean_cuda_device_index(uint32_t u) {
+  (void)u;
+  return torchlean_cuda_device_prop() ? (uint32_t)g_torchlean_cuda_device_index : 0u;
+}
+
+extern "C" LEAN_EXPORT uint32_t torchlean_cuda_device_capability(uint32_t u) {
+  (void)u;
+  const cudaDeviceProp* p = torchlean_cuda_device_prop();
+  return p ? (uint32_t)(p->major * 10 + p->minor) : 0u;
+}
+
+extern "C" LEAN_EXPORT uint32_t torchlean_cuda_device_sm_count(uint32_t u) {
+  (void)u;
+  const cudaDeviceProp* p = torchlean_cuda_device_prop();
+  return p ? (uint32_t)p->multiProcessorCount : 0u;
+}
+
+// The clock and bus-width figures come from `cudaDeviceGetAttribute` rather than from
+// `cudaDeviceProp`, and that is a portability requirement rather than a preference: CUDA 13
+// REMOVED `clockRate` and `memoryClockRate` from the struct, so a build that reads the fields
+// compiles under 12.x and fails to compile under 13.x. The attribute enums are present in both,
+// which is the documented migration path. A device that declines to answer reports 0, the same
+// as the CPU stub.
+static uint32_t torchlean_cuda_device_attr(cudaDeviceAttr attr) {
+  int dev = 0;
+  if (cudaGetDevice(&dev) != cudaSuccess) return 0u;
+  int value = 0;
+  if (cudaDeviceGetAttribute(&value, attr, dev) != cudaSuccess) return 0u;
+  return (uint32_t)value;
+}
+
+extern "C" LEAN_EXPORT uint32_t torchlean_cuda_device_clock_khz(uint32_t u) {
+  (void)u;
+  return torchlean_cuda_device_attr(cudaDevAttrClockRate);
+}
+
+extern "C" LEAN_EXPORT uint32_t torchlean_cuda_device_mem_clock_khz(uint32_t u) {
+  (void)u;
+  return torchlean_cuda_device_attr(cudaDevAttrMemoryClockRate);
+}
+
+extern "C" LEAN_EXPORT uint32_t torchlean_cuda_device_mem_bus_width(uint32_t u) {
+  (void)u;
+  return torchlean_cuda_device_attr(cudaDevAttrGlobalMemoryBusWidth);
+}
+
+extern "C" LEAN_EXPORT uint32_t torchlean_cuda_driver_version(uint32_t u) {
+  (void)u;
+  int v = 0;
+  return cudaDriverGetVersion(&v) == cudaSuccess ? (uint32_t)v : 0u;
+}
+
+extern "C" LEAN_EXPORT uint32_t torchlean_cuda_runtime_version(uint32_t u) {
+  (void)u;
+  int v = 0;
+  return cudaRuntimeGetVersion(&v) == cudaSuccess ? (uint32_t)v : 0u;
+}
+
 extern "C" LEAN_EXPORT uint64_t torchlean_cuda_allocator_cache_bytes(uint32_t u) {
   (void)u;
   torchlean_cuda_lock(&g_torchlean_cuda_cache_mutex, "pthread_mutex_lock cache-bytes query failed");

--- a/csrc/cuda/tensor/torchlean_cuda_tensor_stub.c
+++ b/csrc/cuda/tensor/torchlean_cuda_tensor_stub.c
@@ -211,6 +211,59 @@ LEAN_EXPORT uint64_t torchlean_cuda_allocator_device_total_bytes(uint32_t u) {
   return 0u;
 }
 
+// There is no device in this build, so device identity is the same empty answer a CUDA build gives
+// on a host with no reachable card: "" and zeroes. A caller therefore prints one line under either
+// flavour, and reads the absence off the fields rather than off the build it happens to be in.
+LEAN_EXPORT lean_obj_res torchlean_cuda_compiled_arch_list(uint32_t u) {
+  (void)u;
+  return lean_mk_string("");
+}
+
+LEAN_EXPORT lean_obj_res torchlean_cuda_device_name(uint32_t u) {
+  (void)u;
+  return lean_mk_string("");
+}
+
+LEAN_EXPORT uint32_t torchlean_cuda_device_index(uint32_t u) {
+  (void)u;
+  return 0u;
+}
+
+LEAN_EXPORT uint32_t torchlean_cuda_device_capability(uint32_t u) {
+  (void)u;
+  return 0u;
+}
+
+LEAN_EXPORT uint32_t torchlean_cuda_device_sm_count(uint32_t u) {
+  (void)u;
+  return 0u;
+}
+
+LEAN_EXPORT uint32_t torchlean_cuda_device_clock_khz(uint32_t u) {
+  (void)u;
+  return 0u;
+}
+
+LEAN_EXPORT uint32_t torchlean_cuda_device_mem_clock_khz(uint32_t u) {
+  (void)u;
+  return 0u;
+}
+
+LEAN_EXPORT uint32_t torchlean_cuda_device_mem_bus_width(uint32_t u) {
+  (void)u;
+  return 0u;
+}
+
+LEAN_EXPORT uint32_t torchlean_cuda_driver_version(uint32_t u) {
+  (void)u;
+  return 0u;
+}
+
+LEAN_EXPORT uint32_t torchlean_cuda_runtime_version(uint32_t u) {
+  (void)u;
+  return 0u;
+}
+
 // The CPU stub frees dropped buffers immediately and keeps no reuse cache, so there is nothing to
 // cap and no cached bytes to report.
 LEAN_EXPORT uint64_t torchlean_cuda_allocator_cache_bytes(uint32_t u) {


### PR DESCRIPTION
## Why

A benchmark or a sizing decision that cannot name the device it ran on produces a number that cannot be filed beside another one. `Buffer.allocatorStats` already answers *how much* device memory there is; nothing answered *which device*, and nothing answered which architectures the binary actually holds native code for.

The second gap is the one that bites quietly. Device code is compiled *for* an architecture, and with no `-arch` the toolkit applies its own default. A binary built that way still runs on a newer GPU — through forward PTX JIT — so nothing fails and nothing warns. The timings are then of JIT-generated code for an architecture the compiler was never told about, which is a different measurement from the one a reader will assume.

## What

- **`Buffer.deviceInfo : IO (Option DeviceInfo)`** over `cudaGetDeviceProperties`: name, index, compute capability, SM count, core and memory clocks, memory bus width, total memory, driver and runtime versions.
- **`DeviceInfo.peakBandwidthGBs`**, so a row reporting achieved GB/s can be read as a fraction of the roofline without the reader looking the card up.
- **`Buffer.compiledArchList`** — the binary's own `__CUDA_ARCH_LIST__` (`"860"`, `"750,860"`) — and **`DeviceInfo.runsNatively`**. `DeviceInfo.format` prints the mismatch as a warning:

```
NVIDIA RTX A4500 (device 0, sm_86, 56 SMs, 19.5 GiB, ~640 GB/s peak, driver 13.0, runtime 12.6) [WARNING: compiled for 520, NOT sm_86 — running via PTX JIT]
```

That line is not hypothetical — it is the first thing the check reported on the machine it was written on.

## Shape of the change

Properties are queried once under `pthread_once` and cached; `cudaGetDeviceProperties` is comparatively expensive and its answer cannot change for a device index.

In the CPU stub, and in a CUDA build on a host where no device answers, the name is empty and every scalar is `0`, so `deviceInfo` returns `none`. A caller therefore prints one line under either build flavour and reads the absence off the fields rather than off its own build flavour.

Additions only — 4 files, no existing declaration or symbol changed. The stub carries the matching definitions so the parity build keeps linking.

## Testing

Built and run both flavours on an RTX A4500 (sm_86, CUDA 12.6, driver 13.0):

- CPU stub: `deviceInfo` returns `none`, the caller's line reads as absence.
- CUDA, no `-arch`: reports the device correctly and flags `compiled for 520, NOT sm_86`.
- CUDA, `TORCHLEAN_CUDA_ARCH=sm_86`: warning gone, reads `[compiled for 860]`.

Measured cost of the JIT for the workload in hand: none (24.47 ms against 23.29 ms, within run-to-run scatter). The point is that it was not knowable before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)