### PR TITLE
feat(autograd): reduce the TapeM surface to one lemma, and prove it

### DIFF
--- a/NN/Proofs.lean
+++ b/NN/Proofs.lean
@@ -18,6 +18,7 @@ public import NN.Proofs.Autograd.FDeriv.Params
 public import NN.Proofs.Autograd.Runtime.Link
 public import NN.Proofs.Autograd.Tape.Algebra.Nodes
 public import NN.Proofs.Autograd.Tape.Algebra.Soundness
+public import NN.Proofs.Autograd.Tape.Builder
 public import NN.Proofs.Autograd.Tape.Core.FDeriv
 public import NN.Proofs.Autograd.Tape.Core.Soundness
 public import NN.Proofs.Autograd.Tape.Nodes

--- a/NN/Proofs/Autograd/Tape/Builder.lean
+++ b/NN/Proofs/Autograd/Tape/Builder.lean
@@ -1,0 +1,381 @@
+/-
+Copyright (c) 2026 TorchLean
+Released under MIT license as described in the file LICENSE.
+Authors: TorchLean Team
+-/
+
+module
+
+public import NN.Runtime.Autograd.Engine.TapeM
+
+/-!
+# Reasoning about the tape-builder monad
+
+`Runtime.Autograd.TapeM` is the `StateT (Tape α) Result` wrapper users write eager programs in.
+The pure engine underneath is well covered by proofs; the monadic surface was not, so a `do`-block
+had no route back to a statement about the tape it built. This file supplies that route.
+
+Every op wrapper that threads the tape is definitionally `TapeM.opM` applied to its pure
+counterpart, so the whole surface reduces through one lemma:
+
+- `opM_run_ok` / `opM_run_error` turn a pure op's outcome into the monadic `run`'s outcome, and
+  `opM_run_inv` goes back. Note the pair swaps: a pure op returns tape-then-id, `run` returns
+  value-then-state.
+- `run_bind_inv` splits a successful `run` of `m >>= f` into its two successful stages, which is
+  what peels a `do`-block one statement at a time, and `exec_inv` turns a successful `exec` into
+  such a `run`.
+- The `run_<op>_ok` family below is `opM_run_ok` instantiated at each op's own pure counterpart.
+  Each is a definitional instantiation — the proof term is `opM_run_ok` with `g` supplied, with no
+  unfolding lemma in between — so the family stays correct by construction as ops are added.
+
+`TapeM.leaf` is not in the family: it is total, so its pure counterpart returns a bare pair rather
+than a `Result`, and `run_leaf` states its (unconditional) run directly. `TapeM.backwardScalar` is
+also outside it: it reads the tape without writing one back.
+
+## PyTorch correspondence
+`TapeM` mirrors the imperative style of building a graph by calling ops in sequence and then
+calling `backward`; these lemmas are what lets a proof follow such a program.
+https://pytorch.org/docs/stable/autograd.html
+-/
+
+@[expose] public section
+
+namespace Proofs
+namespace Autograd
+namespace Builder
+
+open Spec
+open Tensor
+open Runtime.Autograd (Tape TapeM Result)
+
+variable {α : Type}
+
+/-! ## The shared reshuffle, reduced once -/
+
+/-- A successful pure op gives a successful monadic run. The pair swaps: the pure op returns
+tape-then-value, `run` returns value-then-state. -/
+theorem opM_run_ok {γ : Type} {g : Tape α → Result (Tape α × γ)} {t t' : Tape α} {v : γ}
+    (h : g t = .ok (t', v)) :
+    (TapeM.opM g).run t = .ok (v, t') := by
+  simp only [TapeM.opM, TapeM.run, StateT.run, bind, StateT.bind, StateT.lift, liftM, monadLift,
+    MonadLift.monadLift, MonadState.get, MonadStateOf.get, getThe, StateT.get,
+    set, MonadStateOf.set, StateT.set, pure, StateT.pure, Except.bind, Except.pure, h]
+
+/-- A failing pure op gives a failing monadic run. -/
+theorem opM_run_error {γ : Type} {g : Tape α → Result (Tape α × γ)} {t : Tape α} {e : String}
+    (h : g t = .error e) :
+    (TapeM.opM g).run t = .error e := by
+  simp only [TapeM.opM, TapeM.run, StateT.run, bind, StateT.bind, StateT.lift, liftM, monadLift,
+    MonadLift.monadLift, MonadState.get, MonadStateOf.get, getThe, StateT.get,
+    pure, Except.bind, Except.pure, h]
+
+/-- Inversion: a successful monadic run means the pure op succeeded. -/
+theorem opM_run_inv {γ : Type} {g : Tape α → Result (Tape α × γ)} {t t' : Tape α} {v : γ}
+    (h : (TapeM.opM g).run t = .ok (v, t')) :
+    g t = .ok (t', v) := by
+  cases hg : g t with
+  | ok p =>
+      obtain ⟨t1, v1⟩ := p
+      rw [opM_run_ok (g := g) (t := t) (t' := t1) (v := v1) hg] at h
+      injection h with h'
+      have h1 : v1 = v := congrArg Prod.fst h'
+      have h2 : t1 = t' := congrArg Prod.snd h'
+      subst h1
+      subst h2
+      rfl
+  | error e =>
+      rw [opM_run_error (g := g) hg] at h
+      cases h
+
+/-! ## Peeling a `do`-block -/
+
+/-- A successful run of `m >>= f` decomposes into its two successful stages. This is what takes a
+`do`-block apart one statement at a time. -/
+theorem run_bind_inv {β γ : Type} {m : TapeM α β} {f : β → TapeM α γ}
+    {t : Tape α} {r : γ × Tape α}
+    (h : (m >>= f).run t = .ok r) :
+    ∃ b t1, m.run t = .ok (b, t1) ∧ (f b).run t1 = .ok r := by
+  have hb : (m >>= f).run t = (m.run t).bind fun bt => (f bt.1).run bt.2 := rfl
+  rw [hb] at h
+  cases hm : m.run t with
+  | error e => rw [hm] at h; cases h
+  | ok bt =>
+      obtain ⟨b1, bt2⟩ := bt
+      rw [hm] at h
+      exact ⟨b1, bt2, rfl, h⟩
+
+/-- A successful `exec` is a successful `run` that returned some value. -/
+theorem exec_inv {β : Type} {m : TapeM α β} {t t' : Tape α}
+    (h : TapeM.exec t m = .ok t') :
+    ∃ b, m.run t = .ok (b, t') := by
+  cases hm : StateT.run m t with
+  | error e =>
+      simp only [TapeM.exec, TapeM.run, bind, Except.bind, hm] at h
+      cases h
+  | ok bt =>
+      obtain ⟨b1, b2⟩ := bt
+      simp only [TapeM.exec, TapeM.run, bind, Except.bind, pure, Except.pure, hm] at h
+      injection h with h'
+      exact ⟨b1, by show StateT.run m t = _; rw [hm, h']⟩
+
+/-! ## `leaf`, which is total -/
+
+/-- `TapeM.leaf` cannot fail, so its run is unconditional. -/
+theorem run_leaf {s : Shape} (value : Tensor α s) (name : Option String := none)
+    (requiresGrad : Bool := true) {t : Tape α} :
+    (TapeM.leaf (α := α) (s := s) value name requiresGrad).run t
+      = .ok ((Tape.leaf (t := t) value (name := name) (requiresGrad := requiresGrad)).2,
+             (Tape.leaf (t := t) value (name := name) (requiresGrad := requiresGrad)).1) := by
+  simp only [TapeM.leaf, TapeM.run, StateT.run, bind, StateT.bind, MonadState.get,
+    MonadStateOf.get, getThe, StateT.get, set, MonadStateOf.set, StateT.set, pure, StateT.pure,
+    Except.bind, Except.pure]
+
+/-! ## The per-op family: `opM_run_ok` at each op's own pure counterpart
+
+Each proof below is `opM_run_ok` with `g` supplied and nothing else. If one of them ever stops
+typechecking, the wrapper it names has stopped being `opM` at its pure op — which is the fact
+worth learning.
+-/
+
+theorem run_add_ok {α : Type} [Add α] [DecidableEq Shape] {s : Shape} (aId bId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.add (t := t) (s := s) aId bId = .ok (t', id)) :
+    (TapeM.add (s := s) aId bId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.add (t := tt) (s := s) aId bId) h
+
+theorem run_sub_ok {α : Type} [Sub α] [Zero α] [DecidableEq Shape] {s : Shape} (aId bId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.sub (t := t) (s := s) aId bId = .ok (t', id)) :
+    (TapeM.sub (s := s) aId bId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.sub (t := tt) (s := s) aId bId) h
+
+theorem run_mul_ok {α : Type} [Mul α] [DecidableEq Shape] {s : Shape} (aId bId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.mul (t := t) (s := s) aId bId = .ok (t', id)) :
+    (TapeM.mul (s := s) aId bId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.mul (t := tt) (s := s) aId bId) h
+
+theorem run_div_ok {α : Type} [Context α] [DecidableEq Shape] {s : Shape} (aId bId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.div (t := t) (s := s) aId bId = .ok (t', id)) :
+    (TapeM.div (s := s) aId bId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.div (t := tt) (s := s) aId bId) h
+
+theorem run_scale_ok {α : Type} [Mul α] [DecidableEq Shape] {s : Shape} (xId : Nat) (c : α)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.scale (t := t) (s := s) xId c = .ok (t', id)) :
+    (TapeM.scale (s := s) xId c).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.scale (t := tt) (s := s) xId c) h
+
+theorem run_abs_ok {α : Type} [Context α] [DecidableRel ((· > ·) : α → α → Prop)]
+    [DecidableEq Shape] {s : Shape} (xId : Nat) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.abs (t := t) (s := s) xId = .ok (t', id)) :
+    (TapeM.abs (s := s) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.abs (t := tt) (s := s) xId) h
+
+theorem run_sqrt_ok {α : Type} [Context α] [DecidableRel ((· > ·) : α → α → Prop)]
+    [DecidableEq Shape] {s : Shape} (xId : Nat) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.sqrt (t := t) (s := s) xId = .ok (t', id)) :
+    (TapeM.sqrt (s := s) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.sqrt (t := tt) (s := s) xId) h
+
+theorem run_clamp_ok {α : Type} [Context α] [DecidableRel ((· > ·) : α → α → Prop)]
+    [DecidableEq Shape] {s : Shape} (xId : Nat) (minVal maxVal : α) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.clamp (t := t) (s := s) xId minVal maxVal = .ok (t', id)) :
+    (TapeM.clamp (s := s) xId minVal maxVal).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.clamp (t := tt) (s := s) xId minVal maxVal) h
+
+theorem run_max_ok {α : Type} [Context α] [DecidableRel ((· > ·) : α → α → Prop)]
+    [DecidableEq Shape] {s : Shape} (aId bId : Nat) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.max (t := t) (s := s) aId bId = .ok (t', id)) :
+    (TapeM.max (s := s) aId bId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.max (t := tt) (s := s) aId bId) h
+
+theorem run_min_ok {α : Type} [Context α] [DecidableRel ((· > ·) : α → α → Prop)]
+    [DecidableEq Shape] {s : Shape} (aId bId : Nat) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.min (t := t) (s := s) aId bId = .ok (t', id)) :
+    (TapeM.min (s := s) aId bId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.min (t := tt) (s := s) aId bId) h
+
+theorem run_relu_ok {α : Type} [Mul α] [Zero α] [Max α] [One α] [LT α]
+    [DecidableRel ((· > ·) : α → α → Prop)] [DecidableEq Shape] {s : Shape} (xId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.relu (t := t) (s := s) xId = .ok (t', id)) :
+    (TapeM.relu (s := s) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.relu (t := tt) (s := s) xId) h
+
+theorem run_linear_ok {α : Type} [Add α] [Mul α] [Zero α] [DecidableEq Shape] {inDim outDim : Nat}
+    (wId bId xId : Nat) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.linear (t := t) (inDim := inDim) (outDim := outDim) wId bId
+      xId = .ok (t', id)) :
+    (TapeM.linear (inDim := inDim) (outDim := outDim) wId bId xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.linear (t := tt) (inDim := inDim)
+    (outDim := outDim) wId bId xId) h
+
+theorem run_matmul_ok {α : Type} [Context α] [DecidableRel ((· > ·) : α → α → Prop)]
+    [DecidableEq Shape] {m n p : Nat} (aId bId : Nat) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.matmul (t := t) (m := m) (n := n) (p := p) aId bId = .ok (t', id)) :
+    (TapeM.matmul (m := m) (n := n) (p := p) aId bId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.matmul (t := tt) (m := m) (n := n) (p := p) aId
+    bId) h
+
+theorem run_conv_ok {α : Type} [Context α] [DecidableRel ((· > ·) : α → α → Prop)]
+    [DecidableEq Shape] {d inC outC : Nat} {kernel stride padding inSpatial : Spec.Tensor Nat [d]}
+    (kernelId biasId inputId : Nat) (name : String) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.conv (t := t) (d := d) (inC := inC) (outC := outC) (kernel := kernel)
+      (stride := stride) (padding := padding) (inSpatial := inSpatial) kernelId biasId inputId
+      (name := name) = .ok (t', id)) :
+    (TapeM.conv (d := d) (inC := inC) (outC := outC) (kernel := kernel) (stride := stride)
+      (padding := padding) (inSpatial := inSpatial) kernelId biasId inputId
+      name).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.conv (t := tt) (d := d) (inC := inC)
+    (outC := outC) (kernel := kernel) (stride := stride) (padding := padding)
+    (inSpatial := inSpatial) kernelId biasId inputId (name := name)) h
+
+theorem run_convTranspose_ok {α : Type} [Context α] [DecidableRel ((· > ·) : α → α → Prop)]
+    [DecidableEq Shape] {d inC outC : Nat} {kernel stride padding : Spec.Tensor Nat [d]}
+    {inSpatial : Spec.Tensor Nat [d]} (kernelId biasId inputId : Nat) (name : String)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.convTranspose (t := t) (d := d) (inC := inC) (outC := outC)
+      (kernel := kernel) (stride := stride) (padding := padding) (inSpatial := inSpatial) kernelId
+      biasId inputId (name := name) = .ok (t', id)) :
+    (TapeM.convTranspose (d := d) (inC := inC) (outC := outC) (kernel := kernel) (stride := stride)
+      (padding := padding) (inSpatial := inSpatial) kernelId biasId inputId
+      name).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.convTranspose (t := tt) (d := d) (inC := inC)
+    (outC := outC) (kernel := kernel) (stride := stride) (padding := padding)
+    (inSpatial := inSpatial) kernelId biasId inputId (name := name)) h
+
+theorem run_maxPool_ok {α : Type} [Context α] [DecidableEq Shape] {d C : Nat}
+    {inSpatial kernel stride padding : Spec.Tensor Nat [d]}
+    {hKernel : ∀ i : Fin d, kernel.getScalar i ≠ 0} (xId : Nat) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.maxPool (t := t) (d := d) (C := C) (inSpatial := inSpatial)
+      (kernel := kernel) (stride := stride) (padding := padding) (hKernel := hKernel)
+      xId = .ok (t', id)) :
+    (TapeM.maxPool (d := d) (C := C) (inSpatial := inSpatial) (kernel := kernel) (stride := stride)
+      (padding := padding) (hKernel := hKernel) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.maxPool (t := tt) (d := d) (C := C)
+    (inSpatial := inSpatial) (kernel := kernel) (stride := stride) (padding := padding)
+    (hKernel := hKernel) xId) h
+
+theorem run_smoothMaxPool_ok {α : Type} [Context α] [DecidableEq α] [DecidableEq Shape] {d C : Nat}
+    {inSpatial kernel stride padding : Spec.Tensor Nat [d]}
+    {hKernel : ∀ i : Fin d, kernel.getScalar i ≠ 0} (xId : Nat) (beta : α) {t t' : Tape α}
+    {id : Nat}
+    (h : Runtime.Autograd.Tape.smoothMaxPool (t := t) (d := d) (C := C) (inSpatial := inSpatial)
+      (kernel := kernel) (stride := stride) (padding := padding) (hKernel := hKernel) xId
+      beta = .ok (t', id)) :
+    (TapeM.smoothMaxPool (d := d) (C := C) (inSpatial := inSpatial) (kernel := kernel)
+      (stride := stride) (padding := padding) (hKernel := hKernel) xId beta).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.smoothMaxPool (t := tt) (d := d) (C := C)
+    (inSpatial := inSpatial) (kernel := kernel) (stride := stride) (padding := padding)
+    (hKernel := hKernel) xId beta) h
+
+theorem run_avgPool_ok {α : Type} [Context α] [DecidableEq Shape] {d C : Nat}
+    {inSpatial kernel stride padding : Spec.Tensor Nat [d]}
+    (hKernel : ∀ i : Fin d, kernel.getScalar i ≠ 0) (xId : Nat) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.avgPool (t := t) (d := d) (C := C) (inSpatial := inSpatial)
+      (kernel := kernel) (stride := stride) (padding := padding) hKernel xId = .ok (t', id)) :
+    (TapeM.avgPool (d := d) (C := C) (inSpatial := inSpatial) (kernel := kernel) (stride := stride)
+      (padding := padding) hKernel xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.avgPool (t := tt) (d := d) (C := C)
+    (inSpatial := inSpatial) (kernel := kernel) (stride := stride) (padding := padding) hKernel
+    xId) h
+
+theorem run_layerNorm_ok {α : Type} [Context α] [DecidableRel ((· > ·) : α → α → Prop)]
+    [DecidableEq Shape] {seqLen embedDim : Nat} (h_seq_pos : seqLen > 0)
+    (h_embed_pos : embedDim > 0) (xId gammaId betaId : Nat) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.layerNorm (t := t) (seqLen := seqLen) (embedDim := embedDim)
+      (h_seq_pos := h_seq_pos) (h_embed_pos := h_embed_pos) xId gammaId betaId = .ok (t', id)) :
+    (TapeM.layerNorm (seqLen := seqLen) (embedDim := embedDim) h_seq_pos h_embed_pos xId gammaId
+      betaId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.layerNorm (t := tt) (seqLen := seqLen)
+    (embedDim := embedDim) (h_seq_pos := h_seq_pos) (h_embed_pos := h_embed_pos) xId gammaId
+    betaId) h
+
+theorem run_batchNorm_ok {α : Type} [Context α] [DecidableRel ((· > ·) : α → α → Prop)]
+    [DecidableEq Shape] {channels : Nat} {sSpatial : Shape}
+    (hWellFormed : (Shape.dim channels sSpatial).wellFormed) (xId gammaId betaId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.batchNorm (t := t) (channels := channels) (sSpatial := sSpatial)
+      hWellFormed xId gammaId betaId = .ok (t', id)) :
+    (TapeM.batchNorm (channels := channels) (sSpatial := sSpatial) hWellFormed xId gammaId
+      betaId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.batchNorm (t := tt) (channels := channels)
+    (sSpatial := sSpatial) hWellFormed xId gammaId betaId) h
+
+theorem run_multiHeadAttention_ok {α : Type} [Context α] [DecidableRel ((· > ·) : α → α → Prop)]
+    [DecidableEq Shape] {n numHeads dModel headDim : Nat} (h1 : n ≠ 0)
+    (wqId wkId wvId woId xId : Nat) (mask : Option (Tensor Bool [n, n])) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.multiHeadAttention (t := t) (n := n) (numHeads := numHeads)
+      (dModel := dModel) (headDim := headDim) (h1 := h1) wqId wkId wvId woId xId
+      mask = .ok (t', id)) :
+    (TapeM.multiHeadAttention (n := n) (numHeads := numHeads) (dModel := dModel)
+      (headDim := headDim) h1 wqId wkId wvId woId xId mask).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.multiHeadAttention (t := tt) (n := n)
+    (numHeads := numHeads) (dModel := dModel) (headDim := headDim) (h1 := h1) wqId wkId wvId woId
+    xId mask) h
+
+theorem run_mseLoss_ok {α : Type} [Add α] [Sub α] [Mul α] [Div α] [Zero α] [One α] [Coe Nat α]
+    [DecidableEq Shape] {s : Shape} (yhatId targetId : Nat) {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.mseLoss (t := t) (s := s) yhatId targetId = .ok (t', id)) :
+    (TapeM.mseLoss (s := s) yhatId targetId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.mseLoss (t := tt) (s := s) yhatId targetId) h
+
+theorem run_sigmoid_ok {α : Type} [Context α] [DecidableEq Shape] {s : Shape} (xId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.sigmoid (t := t) (s := s) xId = .ok (t', id)) :
+    (TapeM.sigmoid (s := s) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.sigmoid (t := tt) (s := s) xId) h
+
+theorem run_tanh_ok {α : Type} [Context α] [DecidableEq Shape] {s : Shape} (xId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.tanh (t := t) (s := s) xId = .ok (t', id)) :
+    (TapeM.tanh (s := s) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.tanh (t := tt) (s := s) xId) h
+
+theorem run_softmaxLast_ok {α : Type} [Context α] [DecidableEq Shape] {s : Shape} (xId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.softmaxLast (t := t) (s := s) xId = .ok (t', id)) :
+    (TapeM.softmaxLast (s := s) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.softmaxLast (t := tt) (s := s) xId) h
+
+theorem run_softplus_ok {α : Type} [Context α] [DecidableEq Shape] {s : Shape} (xId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.softplus (t := t) (s := s) xId = .ok (t', id)) :
+    (TapeM.softplus (s := s) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.softplus (t := tt) (s := s) xId) h
+
+theorem run_exp_ok {α : Type} [Context α] [DecidableEq Shape] {s : Shape} (xId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.exp (t := t) (s := s) xId = .ok (t', id)) :
+    (TapeM.exp (s := s) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.exp (t := tt) (s := s) xId) h
+
+theorem run_log_ok {α : Type} [Context α] [DecidableEq Shape] {s : Shape} (xId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.log (t := t) (s := s) xId = .ok (t', id)) :
+    (TapeM.log (s := s) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.log (t := tt) (s := s) xId) h
+
+theorem run_inv_ok {α : Type} [Context α] [DecidableEq Shape] {s : Shape} (xId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.inv (t := t) (s := s) xId = .ok (t', id)) :
+    (TapeM.inv (s := s) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.inv (t := tt) (s := s) xId) h
+
+theorem run_safeLog_ok {α : Type} [Context α] [DecidableEq Shape] {s : Shape} (xId : Nat) (ε : α)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.safeLog (t := t) (s := s) xId ε = .ok (t', id)) :
+    (TapeM.safeLog (s := s) xId ε).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.safeLog (t := tt) (s := s) xId ε) h
+
+theorem run_sum_ok {α : Type} [Add α] [Zero α] [DecidableEq Shape] {s : Shape} (xId : Nat)
+    {t t' : Tape α} {id : Nat}
+    (h : Runtime.Autograd.Tape.sum (t := t) (s := s) xId = .ok (t', id)) :
+    (TapeM.sum (s := s) xId).run t = .ok (id, t') :=
+  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.sum (t := tt) (s := s) xId) h
+
+end Builder
+end Autograd
+end Proofs

--- a/NN/Runtime/Autograd/Engine/TapeM.lean
+++ b/NN/Runtime/Autograd/Engine/TapeM.lean
@@ -79,6 +79,26 @@ def setTape (t : Tape α) : TapeM α Unit :=
   set t
 
 /--
+The state reshuffle every op wrapper below is made of: read the tape, run the pure `Tape` op on
+it, write the new tape back, and return the fresh node id.
+
+Each wrapper in this namespace whose pure counterpart returns `Result (Tape α × Nat)` is
+*definitionally* `opM` applied to that counterpart — `TapeM.mul aId bId` is
+`opM fun t => Tape.mul (t := t) aId bId`, and so on for the rest. Writing the shared shape once
+gives the wrappers a single point to reason about: `NN.Proofs.Autograd.Tape.Builder` proves how a
+successful, failing, and inverted `run` of `opM g` relate to `g`, and every per-op run lemma there
+is that proof instantiated at the op's own `g`, with no unfolding.
+
+`leaf` is deliberately not in this family: it is total, so its pure counterpart returns a pair
+rather than a `Result`.
+-/
+def opM {γ : Type} (g : Tape α → Result (Tape α × γ)) : TapeM α γ := do
+  let t ← get
+  let (t', id) ← liftM (g t)
+  set t'
+  pure id
+
+/--
 Create a leaf node holding a concrete tensor value.
 
 A leaf is the "input tensor" analogue: it has no parents. Setting `requiresGrad := true`

--- a/NN/Tests/Runtime/Rationals/Suite.lean
+++ b/NN/Tests/Runtime/Rationals/Suite.lean
@@ -8,6 +8,7 @@ module
 
 public import NN.Tests.Runtime.Rationals.AutogradEngineTest
 public import NN.Tests.Runtime.Rationals.ElementwiseDivTest
+public import NN.Tests.Runtime.Rationals.TapeBuilderTest
 
 /-!
 # Suite
@@ -30,6 +31,7 @@ namespace Suite
 def run : IO Unit := do
   Tests.Rationals.AutogradEngine.run
   Tests.Rationals.ElementwiseDiv.run
+  Tests.Rationals.TapeBuilder.run
 
 end Suite
 

--- a/NN/Tests/Runtime/Rationals/TapeBuilderTest.lean
+++ b/NN/Tests/Runtime/Rationals/TapeBuilderTest.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 TorchLean
+Released under MIT license as described in the file LICENSE.
+Authors: TorchLean Team
+-/
+
+module
+
+public import NN.Proofs.Autograd.Tape.Builder
+public import NN.Runtime.Autograd.Train
+public import NN.Tensor
+
+/-!
+# TapeBuilderTest
+
+Exercises `NN.Proofs.Autograd.Tape.Builder` on a user-style eager program over `ℚ`.
+
+The point of the module under test is that a `do`-block written in `TapeM` can be reasoned about,
+not merely run. So this file does both to the same program: it runs it and checks the value, and it
+*proves* — from nothing but "the block executed successfully" — the pure-`Tape` fact behind every
+statement in the block. The proof is the peel: `exec_inv`, then `run_bind_inv` once per statement,
+then `run_leaf` or `opM_run_inv` at each op.
+-/
+
+open scoped NN.Spec.RationalAlgebraic
+
+@[expose] public section
+
+open Spec
+open Tensor
+
+namespace Tests
+namespace Rationals
+namespace TapeBuilder
+
+open Runtime.Autograd
+open Proofs.Autograd.Builder
+
+abbrev tag : String := "tape_builder_test (Rat)"
+
+/-- First input. -/
+def xa : Tensor ℚ [2] := tensorOfArray! [2] #[2, 3]
+
+/-- Second input. -/
+def xb : Tensor ℚ [2] := tensorOfArray! [2] #[5, 7]
+
+/-- The scaling constant. -/
+def c : ℚ := 4
+
+/-- A user-style eager program: two leaves, a product, a scaling. -/
+def prog : TapeM ℚ Nat := do
+  let a ← TapeM.leaf (s := [2]) xa
+  let b ← TapeM.leaf (s := [2]) xb
+  let m ← TapeM.mul (s := [2]) a b
+  TapeM.scale (s := [2]) m c
+
+/--
+A successful execution of `prog` yields the pure-`Tape` fact behind each of its four statements.
+
+Nothing about the tape's contents is assumed: the hypothesis is only that the block ran, and the
+conclusion names the intermediate tapes and node ids the block threaded implicitly.
+-/
+theorem prog_peel {t t' : Tape ℚ} (h : TapeM.exec t prog = .ok t') :
+    ∃ (t1 t2 t3 : Tape ℚ) (ida idb idm ids : Nat),
+      Tape.leaf (t := t) xa = (t1, ida)
+      ∧ Tape.leaf (t := t1) xb = (t2, idb)
+      ∧ Tape.mul (t := t2) (s := [2]) ida idb = .ok (t3, idm)
+      ∧ Tape.scale (t := t3) (s := [2]) idm c = .ok (t', ids) := by
+  obtain ⟨ids, hrun⟩ := exec_inv h
+  obtain ⟨ida, t1, hA, hrest⟩ := run_bind_inv hrun
+  obtain ⟨idb, t2, hB, hrest⟩ := run_bind_inv hrest
+  obtain ⟨idm, t3, hM, hS⟩ := run_bind_inv hrest
+  refine ⟨t1, t2, t3, ida, idb, idm, ids, ?_, ?_, opM_run_inv hM, opM_run_inv hS⟩
+  · rw [run_leaf (t := t) xa] at hA
+    simp only [Except.ok.injEq, Prod.mk.injEq] at hA
+    exact Prod.ext hA.2 hA.1
+  · rw [run_leaf (t := t1) xb] at hB
+    simp only [Except.ok.injEq, Prod.mk.injEq] at hB
+    exact Prod.ext hB.2 hB.1
+
+/-- The program runs, and `4 * (xa * xb)` is `[40, 84]`. -/
+def checkProg : Result Bool := do
+  let (id, t) ← TapeM.run (Tape.empty) prog
+  let out ← Tape.requireValue (t := t) (s := [2]) id
+  pure (decide (pretty out = pretty (tensorOfArray! [2] #[40, 84] : Tensor ℚ [2])))
+
+-- `Tape.empty` has no native implementation available to the elaborator, so `checkProg` cannot be
+-- forced by a compile-time `#guard`; `run` below is what executes it, under the test suite.
+def run : IO Unit := do
+  match checkProg with
+  | .ok true => IO.println s!"{tag}: OK"
+  | .ok false => throw <| IO.userError s!"{tag}: FAILED"
+  | .error msg => throw <| IO.userError s!"{tag}: {msg}"
+
+end TapeBuilder
+end Rationals
+end Tests


### PR DESCRIPTION
### The gap

The pure tape engine (`Runtime.Autograd.Tape`) is well covered by proofs. `TapeM` — the
`StateT (Tape α) Result` wrapper that users actually write eager programs in — has no proofs at
all: `git grep -l TapeM` on `main` finds the runtime definition, the training helpers, and three
test files, and nothing under `NN/Proofs/`. So a `do`-block has no route back to a statement about
the tape it built, and a proof about a program has to be written against a hand-threaded
`Tape.<op>` chain that is not the program.

### The observation this rests on

Every `TapeM` wrapper that threads the tape is the *same* four lines:

```lean
def mul {α : Type} [Mul α] [DecidableEq Shape] {s : Shape}
  (aId bId : Nat) : TapeM α Nat := do
  let t ← get
  let (t', id) ← liftM (Tape.mul (t := t) (s := s) aId bId)
  set t'
  pure id
```

There are 31 of these, differing only in the pure op and its binders. This PR names the shape once:

```lean
def opM {γ : Type} (g : Tape α → Result (Tape α × γ)) : TapeM α γ := do
  let t ← get
  let (t', id) ← liftM (g t)
  set t'
  pure id
```

so each wrapper is *definitionally* `opM` at its own pure counterpart — `TapeM.mul aId bId` is
`opM fun t => Tape.mul (t := t) aId bId`. The existing wrappers are left exactly as they are; the
identity is real either way.

### What the PR adds

`NN/Runtime/Autograd/Engine/TapeM.lean` gains `TapeM.opM` (20 lines, definition + docstring).

`NN/Proofs/Autograd/Tape/Builder.lean` (new) proves, all generic in the carrier `α`:

* `opM_run_ok` / `opM_run_error` — a pure op's outcome becomes the monadic `run`'s outcome. The
  pair swaps: a pure op returns tape-then-value, `run` returns value-then-state.
* `opM_run_inv` — and back again.
* `run_bind_inv` — a successful `run` of `m >>= f` splits into its two successful stages. This is
  what peels a `do`-block one statement at a time.
* `exec_inv` — a successful `exec` is a successful `run` that returned something.
* `run_leaf` — stated separately, because `leaf` is total: its pure counterpart returns a bare pair
  rather than a `Result`.
* `run_<op>_ok` for all 31 tape-threading wrappers — `add`, `sub`, `mul`, `div`, `scale`, `abs`,
  `sqrt`, `clamp`, `max`, `min`, `relu`, `linear`, `matmul`, `conv`, `convTranspose`, `maxPool`,
  `smoothMaxPool`, `avgPool`, `layerNorm`, `batchNorm`, `multiHeadAttention`, `mseLoss`, `sigmoid`,
  `tanh`, `softmaxLast`, `softplus`, `exp`, `log`, `inv`, `safeLog`, `sum`.

Each member of the family is the proof term `opM_run_ok` with `g` supplied and nothing else — no
unfolding lemma in between:

```lean
theorem run_mul_ok {α : Type} [Mul α] [DecidableEq Shape] {s : Shape} (aId bId : Nat)
    {t t' : Tape α} {id : Nat}
    (h : Runtime.Autograd.Tape.mul (t := t) (s := s) aId bId = .ok (t', id)) :
    (TapeM.mul (s := s) aId bId).run t = .ok (id, t') :=
  opM_run_ok (g := fun tt => Runtime.Autograd.Tape.mul (t := tt) (s := s) aId bId) h
```

That is the property worth having: if one of these ever stops typechecking, its wrapper has stopped
being `opM` at its pure op. The family cannot drift into stating something weaker than the wrapper
does, because it is not stating anything separately.

`TapeM.backwardScalar` is deliberately outside the family — it reads the tape without writing one
back, so it is a different shape.

### Axiom profile

The layer contributes nothing of its own. Verified, not assumed:

```
'Runtime.Autograd.TapeM.opM' does not depend on any axioms
'Proofs.Autograd.Builder.opM_run_ok' depends on axioms: [propext]
'Proofs.Autograd.Builder.opM_run_error' depends on axioms: [propext]
'Proofs.Autograd.Builder.opM_run_inv' depends on axioms: [propext]
'Proofs.Autograd.Builder.run_bind_inv' does not depend on any axioms
'Proofs.Autograd.Builder.exec_inv' does not depend on any axioms
```

Where a per-op lemma reports more, it is inherited from the op it names, not introduced here:

```
'Proofs.Autograd.Builder.run_mul_ok'  depends on axioms: [propext]
'Runtime.Autograd.Tape.mul'           depends on axioms: [propext]

'Proofs.Autograd.Builder.run_sum_ok'  depends on axioms: [propext, Quot.sound]
'Runtime.Autograd.Tape.sum'           depends on axioms: [propext, Quot.sound]

'Proofs.Autograd.Builder.run_conv_ok' depends on axioms: [propext, Classical.choice, Quot.sound]
'Runtime.Autograd.Tape.conv'          depends on axioms: [propext, Classical.choice, Quot.sound]
```

### The test does both things to one program

`NN/Tests/Runtime/Rationals/TapeBuilderTest.lean` takes a user-style block over `ℚ`,

```lean
def prog : TapeM ℚ Nat := do
  let a ← TapeM.leaf (s := [2]) xa
  let b ← TapeM.leaf (s := [2]) xb
  let m ← TapeM.mul (s := [2]) a b
  TapeM.scale (s := [2]) m c
```

runs it and checks the value (`4 * ([2,3] * [5,7])` is `[40, 84]`), and *proves* — from nothing but
"the block executed successfully" — the pure-`Tape` fact behind each of its four statements:

```lean
theorem prog_peel {t t' : Tape ℚ} (h : TapeM.exec t prog = .ok t') :
    ∃ (t1 t2 t3 : Tape ℚ) (ida idb idm ids : Nat),
      Tape.leaf (t := t) xa = (t1, ida)
      ∧ Tape.leaf (t := t1) xb = (t2, idb)
      ∧ Tape.mul (t := t2) (s := [2]) ida idb = .ok (t3, idm)
      ∧ Tape.scale (t := t3) (s := [2]) idm c = .ok (t', ids)
```

The proof is the peel and nothing else: `exec_inv`, then `run_bind_inv` once per statement, then
`run_leaf` or `opM_run_inv` at each op.

`Tape.empty` has no native implementation available to the elaborator, so the numeric half cannot
be forced by a compile-time `#guard`; it runs under `nn_tests_suite`, which is where the note in the
file points.

### Checks run

```
lake build                        Build completed successfully (4139 jobs).   [no warnings]
lake exe nn_tests_suite           tape_builder_test (Rat): OK
                                  == TorchLean: all curated tests passed ==
python3 scripts/checks/repo_lint.py   OK: no issues found.
```

### PR checklist

- [x] `lake build` succeeds — 4139 jobs, no errors and no warnings.
- [x] Tests added — `TapeBuilderTest`, wired into `Tests.Runtime.Rationals.Suite`.
- [x] Docstrings on every new definition and theorem; module docstring on the new file.
- [x] Trust boundaries — none crossed; this is proof-layer only, no native or FFI surface.
- [x] No new `sorry` in `NN/`.
- [x] No new axioms.

### Optional follow-up, not in this PR

The 31 wrappers could have their bodies replaced by `opM <their g>`, which would make 
the identity manifest instead of incidental. It is `defeq` either way, 
so the lemmas here hold unchanged. 

Kept out so this PR stays purely additive; happy to do it in a second PR if preferred.

---

## Notes for Nicolas (not part of the PR body)

* Branch exists locally only. `git push -u origin tapem-run-lemmas`, then open the PR against
  `lean-dojo/TorchLean:main`.
* `AI_USAGE.md` upstream discloses AI assistance at the repository level; nothing in this PR needs
  a per-PR disclosure beyond whatever you normally add.
* The working tree was on `cuda-arch-target` before this; `tapem-run-lemmas` was cut from
  `upstream/main`, so it carries none of the CUDA work.
* PKC's `examples/.../TapeMBridge.lean` is the file this generalizes. If this merges, that file
  shrinks to the demo plus the eager-provenance endpoint — its `opM`, the three `opM_run_*` lemmas,
  `run_bind_inv`, `exec_inv` and its 13 per-op lemmas all come from upstream instead, and they
  arrive generic in the carrier rather than fixed at `ℝ`.